### PR TITLE
added command-key attribute

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,5 @@
 /.vs
 /src/WCNet/bin
 /src/WCNet/obj
+/test/WCNet/Tests/bin
+/test/WCNet/Tests/obj

--- a/src/WCNet/Attributes/CommandKeyAttribute.cs
+++ b/src/WCNet/Attributes/CommandKeyAttribute.cs
@@ -1,0 +1,11 @@
+﻿namespace VP.CodingChallenge.WCNet.Attributes;
+
+internal sealed class CommandKeyAttribute : Attribute
+{
+	public String Key { get; }
+
+	public CommandKeyAttribute(String key)
+	{
+		Key = key;
+	}
+}

--- a/src/WCNet/Commands/Concrete/ByteCountCommand.cs
+++ b/src/WCNet/Commands/Concrete/ByteCountCommand.cs
@@ -1,5 +1,8 @@
 ﻿namespace VP.CodingChallenge.WCNet.Commands.Concrete;
 
+using VP.CodingChallenge.WCNet.Attributes;
+
+[CommandKey("-c")]
 internal class ByteCountCommand : ICommand
 {
 	public String Execute(String filepath)

--- a/src/WCNet/Commands/Concrete/LineCountCommand.cs
+++ b/src/WCNet/Commands/Concrete/LineCountCommand.cs
@@ -1,5 +1,8 @@
 ﻿namespace VP.CodingChallenge.WCNet.Commands.Concrete;
 
+using VP.CodingChallenge.WCNet.Attributes;
+
+[CommandKey("-l")]
 internal class LineCountCommand : ICommand
 {
 	public String Execute(String filepath)


### PR DESCRIPTION
# Changes
- Added `CommandKeyAttribute` which keeps the command key attached with the concrete implementation.
- Added `CommandKeyAttribute` onto `ByteCountCommand` and `LineCountCommand`.
- Updated `AddWcNetCommands` and `AddWcNetCommandResolver` extension methods to be flexible, so that registering any new commands does not require any code changes in these methods.