### PR TITLE
added unit-test cases

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,5 +6,5 @@
 /.vs
 /src/WCNet/bin
 /src/WCNet/obj
-/test/WCNet/Tests/bin
-/test/WCNet/Tests/obj
+/test/WCNet/bin
+/test/WCNet/obj

--- a/src/WCNet/Commands/ICommand.cs
+++ b/src/WCNet/Commands/ICommand.cs
@@ -1,4 +1,7 @@
-﻿namespace VP.CodingChallenge.WCNet.Commands;
+﻿using System.Runtime.CompilerServices;
+
+[assembly: InternalsVisibleTo("VP.CodingChallenge.WCNet.Test")]
+namespace VP.CodingChallenge.WCNet.Commands;
 
 internal interface ICommand
 {

--- a/test/WCNet/Unit/CommandResolvers/DefaultCommandResolverTests/Resolve.cs
+++ b/test/WCNet/Unit/CommandResolvers/DefaultCommandResolverTests/Resolve.cs
@@ -1,0 +1,40 @@
+﻿namespace VP.CodingChallenge.WCNet.Test.Unit.CommandResolvers.DefaultCommandResolverTests;
+
+public class Resolve
+{
+	[Fact]
+	public void ReturnsCommandNotFoundInstance_WhenKeyDoesNotExists()
+	{
+		//Arrange
+		var commandMap = new Dictionary<String, ICommand>
+		{
+			{ "-c", new ByteCountCommand() }
+		};
+		var key = "-w";
+		var defaultResolver = new DefaultCommandResolver(commandMap);
+
+		//Act
+		var actualCommand = defaultResolver.Resolve(key);
+
+		//Assert
+		actualCommand.Should().BeOfType<CommandNotFound>();
+	}
+
+	[Fact]
+	public void ReturnsCommandFromTheDictionary_WhenKeyExists()
+	{
+		//Arrange
+		var commandMap = new Dictionary<String, ICommand>
+		{
+			{ "-c", new ByteCountCommand() }
+		};
+		var key = "-c";
+		var defaultResolver = new DefaultCommandResolver(commandMap);
+
+		//Act
+		var actualCommand = defaultResolver.Resolve(key);
+
+		//Assert
+		actualCommand.Should().BeOfType<ByteCountCommand>();
+	}
+}

--- a/test/WCNet/Usings.cs
+++ b/test/WCNet/Usings.cs
@@ -1,0 +1,4 @@
+﻿global using FluentAssertions;
+global using VP.CodingChallenge.WCNet.CommandResolvers;
+global using VP.CodingChallenge.WCNet.Commands;
+global using VP.CodingChallenge.WCNet.Commands.Concrete;

--- a/test/WCNet/VP.CodingChallenge.WCNet.Test.csproj
+++ b/test/WCNet/VP.CodingChallenge.WCNet.Test.csproj
@@ -1,0 +1,28 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFramework>net8.0</TargetFramework>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+
+    <IsPackable>false</IsPackable>
+    <IsTestProject>true</IsTestProject>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="coverlet.collector" Version="6.0.0" />
+    <PackageReference Include="FluentAssertions" Version="6.12.0" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.8.0" />
+    <PackageReference Include="xunit" Version="2.5.3" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.5.3" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\..\src\WCNet\VP.CodingChallenge.WCNet.csproj" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <Using Include="Xunit" />
+  </ItemGroup>
+
+</Project>

--- a/vp-coding-challenge-wcnet.sln
+++ b/vp-coding-challenge-wcnet.sln
@@ -11,6 +11,10 @@ Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "WCNet", "WCNet", "{A941F701
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "VP.CodingChallenge.WCNet", "src\WCNet\VP.CodingChallenge.WCNet.csproj", "{45D68EF0-5EF3-4D38-967A-F3ABCF6775F4}"
 EndProject
+Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "WCNet", "WCNet", "{10AFBDF7-E4FC-4279-A190-F0F286CC9264}"
+EndProject
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "VP.CodingChallenge.WCNet.Test", "test\WCNet\VP.CodingChallenge.WCNet.Test.csproj", "{C827F1D3-884C-4432-A554-962AA6085C38}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -21,6 +25,10 @@ Global
 		{45D68EF0-5EF3-4D38-967A-F3ABCF6775F4}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{45D68EF0-5EF3-4D38-967A-F3ABCF6775F4}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{45D68EF0-5EF3-4D38-967A-F3ABCF6775F4}.Release|Any CPU.Build.0 = Release|Any CPU
+		{C827F1D3-884C-4432-A554-962AA6085C38}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{C827F1D3-884C-4432-A554-962AA6085C38}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{C827F1D3-884C-4432-A554-962AA6085C38}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{C827F1D3-884C-4432-A554-962AA6085C38}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE
@@ -28,6 +36,8 @@ Global
 	GlobalSection(NestedProjects) = preSolution
 		{A941F701-D0D3-4886-801B-87F97E650BE8} = {8F526A11-6F55-4859-8F25-08217E047BE7}
 		{45D68EF0-5EF3-4D38-967A-F3ABCF6775F4} = {A941F701-D0D3-4886-801B-87F97E650BE8}
+		{10AFBDF7-E4FC-4279-A190-F0F286CC9264} = {BB16D67F-6729-4621-944F-6099E0ED5236}
+		{C827F1D3-884C-4432-A554-962AA6085C38} = {10AFBDF7-E4FC-4279-A190-F0F286CC9264}
 	EndGlobalSection
 	GlobalSection(ExtensibilityGlobals) = postSolution
 		SolutionGuid = {8A790F20-4B3F-4800-87B9-DD76861525EE}


### PR DESCRIPTION
# Changes
- Added unit-test cases for `DefaultCommandResolver.cs`
- Added global `Using.cs` in `VP.CodingChallenge.WCNet.Test.csproj`.
- Exposed namespace `VP.CodingChallenge.WCNet.Commands` to test project.