### PR TITLE
refactor/wcnet

### DIFF
--- a/src/WCNet/CommandErrors/CommandExecutionError.cs
+++ b/src/WCNet/CommandErrors/CommandExecutionError.cs
@@ -1,0 +1,20 @@
+﻿namespace VP.CodingChallenge.WCNet.CommandErrors;
+
+internal class CommandExecutionError : Error
+{
+    private readonly String _message;
+
+    private CommandExecutionError(String message)
+        : base(message)
+    {
+        _message = message;
+    }
+
+    public static CommandExecutionError Create(String commandKey)
+        => new CommandExecutionError($"Error executing command: {commandKey}.");
+
+    public static CommandExecutionError Create(String commandKey, Exception exception)
+        => new CommandExecutionError($"Error executing command: {commandKey}: {exception.Message}.");
+
+    public override String ToString() => _message;
+}

--- a/src/WCNet/CommandErrors/CommandFormatError.cs
+++ b/src/WCNet/CommandErrors/CommandFormatError.cs
@@ -2,12 +2,16 @@
 
 internal class CommandFormatError : Error
 {
+    private readonly String _message;
+
 	private CommandFormatError(String message)
 		: base(message)
 	{
-
+        _message = message;
 	}
 
 	internal static CommandFormatError Create()
 		=> new CommandFormatError("Incorrect command format, try -<command> <filepath_along_with_filename.extension>.");
+
+    public override String ToString() => _message;
 }

--- a/src/WCNet/CommandErrors/CommandNotFoundError.cs
+++ b/src/WCNet/CommandErrors/CommandNotFoundError.cs
@@ -2,12 +2,16 @@
 
 internal class CommandNotFoundError : Error
 {
-	private CommandNotFoundError(String message)
+    private readonly String _message;
+
+    private CommandNotFoundError(String message)
 		: base(message)
 	{
-
+        _message = message;
 	}
 
 	internal static CommandNotFoundError Create(CommandKey command)
-		=> new CommandNotFoundError($"Command: {command} not found.");
+		=> new CommandNotFoundError($"Command: \"{command}\" not found.");
+
+    public override String ToString() => _message;
 }

--- a/src/WCNet/CommandErrors/FileExtensionNotAllowedError.cs
+++ b/src/WCNet/CommandErrors/FileExtensionNotAllowedError.cs
@@ -2,12 +2,16 @@
 
 internal class FileExtensionNotAllowedError : Error
 {
-	private FileExtensionNotAllowedError(String message)
+    private readonly String _message;
+
+    private FileExtensionNotAllowedError(String message)
 		: base(message)
 	{
-
+        _message = message;
 	}
 
 	internal static FileExtensionNotAllowedError Create(String fileExtension)
-		=> new FileExtensionNotAllowedError($"File extension: .{fileExtension}, is not allowed.");
+		=> new FileExtensionNotAllowedError($"File extension: \".{fileExtension}\", is not allowed.");
+
+    public override String ToString() => _message;
 }

--- a/src/WCNet/CommandErrors/FileNotFoundError.cs
+++ b/src/WCNet/CommandErrors/FileNotFoundError.cs
@@ -2,12 +2,16 @@
 
 internal class FileNotFoundError : Error
 {
-	private FileNotFoundError(String message)
+    private readonly String _message;
+
+    private FileNotFoundError(String message)
 		: base(message)
 	{
-
+        _message = message;
 	}
 
 	internal static FileNotFoundError Create(String filename)
 		=> new FileNotFoundError($"File: {filename}, not found.");
+
+    public override String ToString() => _message;
 }

--- a/src/WCNet/CommandHandlers/CommandHandlerBase.cs
+++ b/src/WCNet/CommandHandlers/CommandHandlerBase.cs
@@ -2,24 +2,36 @@
 
 public abstract class CommandHandlerBase
 {
-    internal abstract Result<CommandArgument> PreHandle(String[] args);
-    internal abstract Result<Message> Handle(CommandArgument commandArgument);
-    internal abstract Result PostHandle(Message message);
+    protected abstract Result<CommandArgument> PreHandle(String[] args);
+    protected abstract Result<Message> Handle(CommandArgument commandArgument);
+    protected abstract Result PostHandle(Message message);
 
     public void Main(String[] args)
     {
-        var argumentResult = PreHandle(args);
-        if (argumentResult.IsFailed)
-        {
-            //Write to console why it failed
-        }
+        var commandKey = new CommandKey();
 
-        var messageResult = Handle(argumentResult.Value);
-        if (messageResult.IsFailed)
+        try
         {
-            //Write to console why it failed
-        }
+            var argumentResult = PreHandle(args);
+            if (argumentResult.IsFailed)
+            {
+                Console.WriteLine(argumentResult.Error);
+                return;
+            }
 
-        PostHandle(messageResult.Value);
+            commandKey = argumentResult.Value.CommandKey;
+            var messageResult = Handle(argumentResult.Value);
+            if (messageResult.IsFailed)
+            {
+                Console.WriteLine(messageResult.Error);
+                return;
+            }
+
+            PostHandle(messageResult.Value);
+        }
+        catch (Exception ex)
+        {
+            Console.WriteLine($"Error executing command: {commandKey}: {ex.Message}");
+        }
     }
 }

--- a/src/WCNet/CommandHandlers/DefaultCommandHandler.cs
+++ b/src/WCNet/CommandHandlers/DefaultCommandHandler.cs
@@ -1,29 +1,32 @@
 ﻿namespace VP.CodingChallenge.WCNet.CommandHandlers;
 
-using LightResults;
-
 internal class DefaultCommandHandler : CommandHandlerBase
 {
     private readonly ICommandResolver _commandResolver;
     private readonly ICommandParser _commandParser;
 
-	public DefaultCommandHandler(ICommandResolver commandResolver, ICommandParser commandParser)
+    public DefaultCommandHandler(ICommandResolver commandResolver, ICommandParser commandParser)
 	{
 		_commandResolver = commandResolver;
         _commandParser = commandParser;
 	}
 
-	internal override Result<Message> Handle(CommandArgument commandArgument)
+    protected override Result<Message> Handle(CommandArgument commandArgument)
 	{
         var command = _commandResolver.Resolve(commandArgument.CommandKey);
         var text = command.Execute(commandArgument.Filepath);
+        if (String.IsNullOrEmpty(text))
+        {
+            return Result<Message>.Fail(CommandExecutionError.Create(commandArgument.CommandKey));
+        }
+
         return Result<Message>.Ok(text);
 	}
 
-    internal override Result PostHandle(Message message)
+    protected override Result PostHandle(Message message)
     {
         Console.WriteLine(message);
         return Result.Ok();
     }
-    internal override Result<CommandArgument> PreHandle(String[] args) => _commandParser.Parse(args);
+    protected override Result<CommandArgument> PreHandle(String[] args) => _commandParser.Parse(args);
 }

--- a/src/WCNet/CommandModels/CommandArgument.cs
+++ b/src/WCNet/CommandModels/CommandArgument.cs
@@ -1,26 +1,71 @@
 ﻿namespace VP.CodingChallenge.WCNet.CommandModels;
 
-internal class CommandArgument : IEquatable<CommandArgument>
+/// <summary>
+/// Class CommandArgument
+/// </summary>
+public class CommandArgument : IEquatable<CommandArgument>
 {
-	internal CommandKey CommandKey { get; }
-	internal String Filepath { get; } = String.Empty;
+    /// <summary>
+    /// Gets the <see cref="CommandModels.CommandKey"/>
+    /// </summary>
+	public CommandKey CommandKey { get; }
 
+    /// <summary>
+    /// Gets the Filepath
+    /// </summary>
+	public String Filepath { get; } = String.Empty;
+
+    /// <summary>
+    /// Initializes a new instance of <see cref="CommandArgument"/>.
+    /// </summary>
+    /// <param name="commandKey">The <see cref="CommandModels.CommandKey"/></param>
+    /// <param name="filepath">The filepath</param>
 	private CommandArgument(CommandKey commandKey, String filepath)
 	{
 		CommandKey = commandKey;
 		Filepath = filepath;
 	}
 
-	public static CommandArgument Create(CommandKey commandKey, String filename) => new CommandArgument(commandKey, filename);
+    /// <summary>
+    /// Creates a new instance of <see cref="CommandArgument"/>.
+    /// </summary>
+    /// <param name="commandKey">The <see cref="CommandModels.CommandKey"/></param>
+    /// <param name="filepath">The filepath</param>
+    /// <returns>An instance of <see cref="CommandArgument"/>.</returns>
+	public static CommandArgument Create(CommandKey commandKey, String filepath) => new CommandArgument(commandKey, filepath);
 
+    /// <summary>
+    /// Determines whether the <paramref name="other"/> (<see cref="CommandArgument"/>) is equal to the current <see cref="CommandArgument"/>.
+    /// </summary>
+    /// <param name="other">The other <see cref="CommandArgument"/></param>
+    /// <returns>True if other (<see cref="CommandArgument"/>) instance is equal to the current <see cref="CommandArgument"/>; otherwise, false.</returns>
 	public Boolean Equals(CommandArgument? other) => this == other;
 
+    /// <summary>
+    /// Determines whether the <paramref name="obj"/> (<see cref="Object?"/>) is equal to the current instance.
+    /// </summary>
+    /// <param name="obj">The obj <see cref="Object?"/></param>
+    /// <returns>True if obj (<see cref="Object?"/>) instance is equal to the current instance; otherwise, false.</returns>
 	public override Boolean Equals(Object? obj) => obj is not null && obj is CommandArgument other && Equals(other);
 
+    /// <summary>
+    /// Gets the hash code for the <see cref="CommandArgument"/>.
+    /// </summary>
+    /// <returns>A hash code for the current <see cref="CommandArgument"/>.</returns>
 	public override Int32 GetHashCode() => HashCode.Combine(CommandKey, Filepath);
 
+    /// <summary>
+    /// Gets the string representation of <see cref="CommandArgument"/>.
+    /// </summary>
+    /// <returns>The string representation of <see cref="CommandArgument"/>.</returns>
 	public override String ToString() => $"Command: {CommandKey}, Filename: \"{Path.GetFileName(Filepath)}\"";
 
+    /// <summary>
+    /// Determines whether two specified <see cref="CommandArgument"/> instances are equal.
+    /// </summary>
+    /// <param name="left">The <see cref="CommandArgument"/> instance on the left</param>
+    /// <param name="right">The <see cref="CommandArgument"/> instance on the right</param>
+    /// <returns>True if the two specified <see cref="CommandArgument"/> instances are equal; otherwise, false.</returns>
 	public static Boolean operator ==(CommandArgument? left, CommandArgument? right)
 	{
 		if (ReferenceEquals(left, right))
@@ -36,5 +81,11 @@ internal class CommandArgument : IEquatable<CommandArgument>
 		return left.CommandKey.Equals(right.CommandKey) && String.Equals(left.Filepath, right.Filepath);
 	}
 
+    /// <summary>
+    /// Determines whether two specified <see cref="CommandArgument"/> instances are not equal.
+    /// </summary>
+    /// <param name="left">The <see cref="CommandArgument"/> instance on the left</param>
+    /// <param name="right">The <see cref="CommandArgument"/> instance on the right</param>
+    /// <returns>True if the two specified <see cref="CommandArgument"/> instances are not equal; otherwise, false.</returns>
 	public static Boolean operator !=(CommandArgument? left, CommandArgument? right) => !(left == right);
 }

--- a/src/WCNet/CommandModels/CommandKey.cs
+++ b/src/WCNet/CommandModels/CommandKey.cs
@@ -1,6 +1,6 @@
 ﻿namespace VP.CodingChallenge.WCNet.CommandModels;
 
-internal readonly struct CommandKey : IEquatable<CommandKey>
+public readonly struct CommandKey : IEquatable<CommandKey>
 {
 	public String Value { get; }
 

--- a/src/WCNet/CommandModels/Message.cs
+++ b/src/WCNet/CommandModels/Message.cs
@@ -1,14 +1,14 @@
 ﻿namespace VP.CodingChallenge.WCNet.CommandModels;
 
-internal readonly struct Message : IEquatable<Message>
+public readonly struct Message : IEquatable<Message>
 {
-    internal String Text { get; }
+    public String Text { get; }
 
     /// <summary>
     /// Initializes a new instance of the <see cref="Message"/> struct.
     /// </summary>
     /// <param name="text">The text</param>
-    internal Message(String text)
+    public Message(String text)
     {
         Text = text;
     }

--- a/src/WCNet/CommandParsers/DefaultCommandParser.cs
+++ b/src/WCNet/CommandParsers/DefaultCommandParser.cs
@@ -13,7 +13,7 @@ internal class DefaultCommandParser : ICommandParser
 	{
 		if (args.Length != 2)
 		{
-			return Result<CommandArgument>.Fail(CommandFormatError.Create());
+            return Result<CommandArgument>.Fail(CommandFormatError.Create());
 		}
 
 		var commandRegex = new Regex(_options.CommandExpression);

--- a/src/WCNet/Startup/Program.cs
+++ b/src/WCNet/Startup/Program.cs
@@ -3,26 +3,18 @@
 public class Program
 {
 	private static readonly IServiceCollection ServiceCollection = new ServiceCollection();
+    private static readonly IConfigurationBuilder ConfigurationBuilder = new ConfigurationBuilder();
 
 	static void Main(String[] args)
 	{
-		//WC configuration provider
-		var configuration = GetWcConfigurationBuilder().Build();
+		//Build WcNet configuration
+		var configuration = ConfigurationBuilder.BuildWcNetConfiguration();
 
-		//WC service provider
+		//Build WcNet service provider
 		var serviceProvider = ServiceCollection.BuildWcNetServiceProvider(configuration);
 
-		//Execute DefaultCommandHandler.Handle
+		//Execute CommandHandlerBase.Main
 		var commandHandler = serviceProvider.GetRequiredService<CommandHandlerBase>();
 		commandHandler.Main(args);
-	}
-
-	internal static IConfigurationBuilder GetWcConfigurationBuilder()
-	{
-		var builder = new ConfigurationBuilder()
-			.SetBasePath(Directory.GetCurrentDirectory())
-			.AddJsonFile("appsettings.json", optional: true, reloadOnChange: true);
-
-		return builder;
 	}
 }

--- a/src/WCNet/Startup/WcNetConfigurationExtension.cs
+++ b/src/WCNet/Startup/WcNetConfigurationExtension.cs
@@ -1,0 +1,10 @@
+﻿namespace VP.CodingChallenge.WCNet.Startup;
+
+internal static class WcNetConfigurationExtension
+{
+    internal static IConfiguration BuildWcNetConfiguration(this IConfigurationBuilder builder)
+        => builder
+            .SetBasePath(Directory.GetCurrentDirectory())
+            .AddJsonFile("appsettings.json", optional: true, reloadOnChange: true)
+            .Build();
+}

--- a/test/WCNet/Unit/CommandHandlers/CommandHandlerBaseTests/Main.cs
+++ b/test/WCNet/Unit/CommandHandlers/CommandHandlerBaseTests/Main.cs
@@ -1,0 +1,107 @@
+﻿namespace VP.CodingChallenge.WCNet.Test.Unit.CommandHandlers.CommandHandlerBaseTests;
+
+public class Main
+{
+    /// <summary>
+    /// Executes the action and returns the output written to the Console.
+    /// It redirects "Console.Out" to a "StringWriter", so that output written to the console can be captured and examined during testing.
+    /// </summary>
+    /// <param name="action">The action</param>
+    /// <returns>A string from Console.</returns>
+    private static String CaptureConsoleOutput(Action action)
+    {
+        var stringWriter = new StringWriter();
+        var originalOutput = Console.Out;
+        Console.SetOut(stringWriter);
+
+        try
+        {
+            action();
+        }
+        finally
+        {
+            Console.SetOut(originalOutput);
+        }
+
+        return stringWriter.ToString();
+    }
+
+    [Fact]
+    public void OutputsCommandNotFoundErrorMessage_WhenPreHandleFails()
+    {
+        //Arrange
+        var commandKey = new CommandKey("-w");
+        var args = new String[] { "-c", "filename.txt" };
+        var preHandleResult = Result<CommandArgument>.Fail(CommandNotFoundError.Create(commandKey));
+        var commandArgs = CommandArgument.Create(commandKey, "filename.txt");
+        var messageResult = Result<Message>.Ok(new Message("Success"));
+        var message = messageResult.Value;
+        var testHandler = new TestCommandHandler(
+            args => preHandleResult,
+            commandArgs => messageResult,
+            message => Result.Ok());
+        var expectedOutput = $"Command: \"{commandKey}\" not found.";
+
+        //Act
+        var actualOutput = CaptureConsoleOutput(() => testHandler.Main(args)).TrimEnd('\r', '\n'); ;
+
+        //Assert
+        actualOutput.Should()
+            .NotBeNullOrEmpty().And
+            .Be(expectedOutput);
+    }
+
+    [Fact]
+    public void OutputsCommandExecutionErrorMessage_WhenHandleFails()
+    {
+        //Arrange
+        var commandKey = new CommandKey("-c");
+        var args = new String[] { "-c", "filename.txt" };
+        var commandArgs = CommandArgument.Create(commandKey, "filename.txt");
+        var preHandleResult = Result<CommandArgument>.Ok(commandArgs);
+        var message = new Message("Success");
+        var messageResult = Result<Message>.Fail(CommandExecutionError.Create(commandKey));
+        var testHandler = new TestCommandHandler(
+            args => preHandleResult,
+            commandArgs => messageResult,
+            message => Result.Ok());
+        var expectedOutput = $"Error executing command: {commandKey}.";
+
+        //Act
+        var actualOutput = CaptureConsoleOutput(() => testHandler.Main(args)).TrimEnd('\r', '\n');
+
+        //Assert
+        actualOutput.Should()
+            .NotBeNullOrEmpty().And
+            .Be(expectedOutput);
+    }
+
+    [Fact]
+    public void OutputsSuccessMessage_WhenCommandExecutesSuccessfully()
+    {
+        //Arrange
+        var commandKey = new CommandKey("-c");
+        var args = new String[] { "-c", "filename.txt" };
+        var commandArgs = CommandArgument.Create(commandKey, "filename.txt");
+        var preHandleResult = Result<CommandArgument>.Ok(commandArgs);
+        var message = new Message("342190 filename.txt");
+        var messageResult = Result<Message>.Ok(message);
+        var testHandler = new TestCommandHandler(
+            args => preHandleResult,
+            commandArgs => messageResult,
+            message =>
+            {
+                Console.WriteLine(message);
+                return Result.Ok();
+            });
+        var expectedOutput = "342190 filename.txt";
+
+        //Act
+        var actualOutput = CaptureConsoleOutput(() => testHandler.Main(args)).TrimEnd('\r', '\n');
+
+        //Assert
+        actualOutput.Should()
+            .NotBeNullOrEmpty().And
+            .Be(expectedOutput);
+    }
+}

--- a/test/WCNet/Unit/CommandHandlers/TestCommandHandler.cs
+++ b/test/WCNet/Unit/CommandHandlers/TestCommandHandler.cs
@@ -1,0 +1,22 @@
+﻿namespace VP.CodingChallenge.WCNet.Test.Unit.CommandHandlers;
+
+internal class TestCommandHandler : CommandHandlerBase
+{
+    private readonly Func<String[], Result<CommandArgument>> _preHandle;
+    private readonly Func<CommandArgument, Result<Message>> _handle;
+    private readonly Func<Message, Result> _postHandle;
+
+    public TestCommandHandler(
+        Func<String[], Result<CommandArgument>> preHandle,
+        Func<CommandArgument, Result<Message>> handle,
+        Func<Message, Result> postHandle)
+    {
+        _preHandle = preHandle;
+        _handle = handle;
+        _postHandle = postHandle;
+    }
+
+    protected override Result<Message> Handle(CommandArgument commandArgument) => _handle(commandArgument);
+    protected override Result PostHandle(Message message) => _postHandle(message);
+    protected override Result<CommandArgument> PreHandle(String[] args) => _preHandle(args);
+}

--- a/test/WCNet/Unit/CommandModels/CommandArgumentTests/Equals.cs
+++ b/test/WCNet/Unit/CommandModels/CommandArgumentTests/Equals.cs
@@ -1,0 +1,179 @@
+﻿namespace VP.CodingChallenge.WCNet.Test.Unit.CommandModels.CommandArgumentTests;
+
+public class Equals
+{
+    #region IEquatable<CommandArgument>.Equals
+    [Fact]
+    public void ReturnsFalse_WhenInstancesAreNotEqual()
+    {
+        //Arrange
+        var other = CommandArgument.Create("-c", "filepath");
+        var current = CommandArgument.Create("-c", "fake-filepath");
+
+        //Assert
+        var actual = current.Equals(other);
+
+        //Assert
+        actual.Should().BeFalse();
+    }
+
+    [Fact]
+    public void ReturnsTrue_WhenInstancesAreEqual()
+    {
+        //Arrange
+        var other = CommandArgument.Create("-c", "filepath");
+        var current = CommandArgument.Create("-c", "filepath");
+
+        //Assert
+        var actual = current.Equals(other);
+
+        //Assert
+        actual.Should().BeTrue();
+    }
+    #endregion IEquatable<CommandArgument>.Equals
+
+    #region IEquatable<CommandArgument>.Equals(Object? obj)
+    [Fact]
+    public void ReturnsFalse_WhenObjectIsNull()
+    {
+        //Arrange
+        var obj = (Object?)null;
+        var current = CommandArgument.Create("-c", "filepath");
+
+        //Act
+        var actual = current.Equals(obj);
+
+        //Assert
+        actual.Should().BeFalse();
+    }
+
+    [Fact]
+    public void ReturnsFalse_WhenObjectIsNotOfTypeCommandArgument()
+    {
+        //Arrange
+        var obj = (Object?)new CommandKey("-c");
+        var current = CommandArgument.Create("-c", "filepath");
+
+        //Act
+        var actual = current.Equals(obj);
+
+        //Assert
+        actual.Should().BeFalse();
+    }
+
+    [Fact]
+    public void ReturnsFalse_WhenObjectIsOfTypeCommandArgumentButOneOfThePropertiesDoesNotMatch()
+    {
+        //Arrange
+        var obj = (Object?)CommandArgument.Create("-c", "fake-filepath");
+        var current = CommandArgument.Create("-c", "filepath");
+
+        //Act
+        var actual = current.Equals(obj);
+
+        //Assert
+        actual.Should().BeFalse();
+    }
+
+    [Fact]
+    public void ReturnsTrue_WhenObjectIsOfTypeCommandArgumentAndAllThePropertiesMatch()
+    {
+        //Arrange
+        var obj = (Object?)CommandArgument.Create("-c", "filepath");
+        var current = CommandArgument.Create("-c", "filepath");
+
+        //Act
+        var actual = current.Equals(obj);
+
+        //Assert
+        actual.Should().BeTrue();
+    }
+
+    #endregion IEquatable<CommandArgument>.Equals(Object? obj)
+
+    #region == Operator
+    [Fact]
+    public void ReturnsFalse_WhenOperandLeftIsNull()
+    {
+        //Arrange
+        var left = (CommandArgument)null!;
+        var right = CommandArgument.Create("-c", "filepath");
+
+        //Act
+        var actual = left == right;
+
+        //Assert
+        actual.Should().BeFalse();
+    }
+
+    [Fact]
+    public void ReturnsFalse_WhenOperandRightIsNull()
+    {
+        //Arrange
+        var left = CommandArgument.Create("-c", "filepath");
+        var right = (CommandArgument)null!;
+
+        //Act
+        var actual = left == right;
+
+        //Assert
+        actual.Should().BeFalse();
+    }
+
+    [Fact]
+    public void ReturnsFalse_WhenCommandKeyMatchesButFilepathDoesNot()
+    {
+        //Arrange
+        var left = CommandArgument.Create("-c", "filepath");
+        var right = CommandArgument.Create("-c", "fake-filepath");
+
+        //Act
+        var actual = left == right;
+
+        //Assert
+        actual.Should().BeFalse();
+    }
+
+    [Fact]
+    public void ReturnsFalse_WhenFilepathMatchesButCommandKeyDoesNot()
+    {
+        //Arrange
+        var left = CommandArgument.Create("-c", "filepath");
+        var right = CommandArgument.Create("-w", "filepath");
+
+        //Act
+        var actual = left == right;
+
+        //Assert
+        actual.Should().BeFalse();
+    }
+
+    [Fact]
+    public void ReturnsTrue_WhenOperandsAreNull()
+    {
+        //Arrange
+        var left = (CommandArgument)null!;
+        var right = (CommandArgument)null!;
+
+        //Act
+        var actual = left == right;
+
+        //Assert
+        actual.Should().BeTrue();
+    }
+
+    [Fact]
+    public void ReturnsTrue_WhenOperandsBothCommandKeyAndFilepathAreEqual()
+    {
+        //Arrange
+        var left = CommandArgument.Create("-c", "filepath");
+        var right = CommandArgument.Create("-c", "filepath");
+
+        //Act
+        var actual = left == right;
+
+        //Assert
+        actual.Should().BeTrue();
+    }
+    #endregion == Operator
+}

--- a/test/WCNet/Unit/CommandModels/CommandArgumentTests/GetHashCode.cs
+++ b/test/WCNet/Unit/CommandModels/CommandArgumentTests/GetHashCode.cs
@@ -1,0 +1,64 @@
+﻿namespace VP.CodingChallenge.WCNet.Test.Unit.CommandModels.CommandArgumentTests;
+
+public class GetHashCode
+{
+    [Fact]
+    public void ReturnsSameValue_WhenSameObjectIsCalledMultipleTimes()
+    {
+        //Arrange
+        var commandArgs = CommandArgument.Create("-c", "filepath");
+        var hash_1 = commandArgs.GetHashCode();
+        var hash_2 = commandArgs.GetHashCode();
+
+        //Act
+        var actual = hash_1.Equals(hash_2);
+
+        //Assert
+        actual.Should().BeTrue();
+    }
+
+    [Fact]
+    public void ReturnsSameValue_ForEqualObjects()
+    {
+        //Arrange
+        var commandArgs_1 = CommandArgument.Create("-c", "filepath");
+        var commandArgs_2 = CommandArgument.Create("-c", "filepath");
+
+        //Act
+        var hash_1 = commandArgs_1.GetHashCode();
+        var hash_2 = commandArgs_2.GetHashCode();
+
+        //Assert
+        hash_1.Should().Be(hash_2);
+    }
+
+    [Fact]
+    public void ReturnsDifferentValue_WhenCommandKeyMatchesButFilepathDoesNotMatch()
+    {
+        //Arrange
+        var commandArgs_1 = CommandArgument.Create("-c", "filepath");
+        var commandArgs_2 = CommandArgument.Create("-c", "fake-filepath");
+
+        //Act
+        var hash_1 = commandArgs_1.GetHashCode();
+        var hash_2 = commandArgs_2.GetHashCode();
+
+        //Assert
+        hash_1.Should().NotBe(hash_2);
+    }
+
+    [Fact]
+    public void ReturnsDifferentValue_WhenFilepathMatchesButCommandKeyDoesNotMatch()
+    {
+        //Arrange
+        var commandArgs_1 = CommandArgument.Create("-c", "filepath");
+        var commandArgs_2 = CommandArgument.Create("-l", "filepath");
+
+        //Act
+        var hash_1 = commandArgs_1.GetHashCode();
+        var hash_2 = commandArgs_2.GetHashCode();
+
+        //Assert
+        hash_1.Should().NotBe(hash_2);
+    }
+}

--- a/test/WCNet/Unit/CommandModels/CommandArgumentTests/NotEquals.cs
+++ b/test/WCNet/Unit/CommandModels/CommandArgumentTests/NotEquals.cs
@@ -1,0 +1,32 @@
+﻿namespace VP.CodingChallenge.WCNet.Test.Unit.CommandModels.CommandArgumentTests;
+
+public class NotEquals
+{
+    [Fact]
+    public void ReturnsFalse_WhenInstancesAreEqual()
+    {
+        //Arrange
+        var left = CommandArgument.Create("-c", "filepath");
+        var right = CommandArgument.Create("-c", "filepath");
+
+        //Act
+        var actual = left != right;
+
+        //Assert
+        actual.Should().BeFalse();
+    }
+
+    [Fact]
+    public void ReturnsTrue_WhenInstancesAreNotEqual()
+    {
+        //Arrange
+        var left = CommandArgument.Create("-c", "filepath");
+        var right = CommandArgument.Create("-c", "fake-filepath");
+
+        //Act
+        var actual = left != right;
+
+        //Assert
+        actual.Should().BeTrue();
+    }
+}

--- a/test/WCNet/Unit/CommandModels/CommandArgumentTests/ToString.cs
+++ b/test/WCNet/Unit/CommandModels/CommandArgumentTests/ToString.cs
@@ -1,0 +1,21 @@
+﻿namespace VP.CodingChallenge.WCNet.Test.Unit.CommandModels.CommandArgumentTests;
+
+public class ToString
+{
+    [Fact]
+    public void ReturnsStringContainingCommandKeyAndFilepath()
+    {
+        //Arrange
+        var commandKey = new CommandKey("-c");
+        var filename = "filename.txt";
+        var filepath = Path.Combine($".\\filepath\\{filename}");
+        var commandArgs = CommandArgument.Create(commandKey, filepath);
+        var expected = $"Command: {commandKey}, Filename: \"{filename}\"";
+
+        //Act
+        var actual = commandArgs.ToString();
+
+        //Assert
+        actual.Should().Be(expected);
+    }
+}

--- a/test/WCNet/Unit/CommandModels/CommandKeyTests/Equals.cs
+++ b/test/WCNet/Unit/CommandModels/CommandKeyTests/Equals.cs
@@ -1,0 +1,165 @@
+﻿namespace VP.CodingChallenge.WCNet.Test.Unit.CommandModels.CommandKeyTests;
+
+public class Equals
+{
+    #region IEquatable<CommandKey>.Equals
+    [Fact]
+    public void ReturnsFalse_WhenInstancesAreNotEqual()
+    {
+        //Arrange
+        var other = new CommandKey("-c");
+        var current = new CommandKey("-w");
+
+        //Assert
+        var actual = current.Equals(other);
+
+        //Assert
+        actual.Should().BeFalse();
+    }
+
+    [Fact]
+    public void ReturnsTrue_WhenInstancesAreEqual()
+    {
+        //Arrange
+        var other = new CommandKey("-c");
+        var current = new CommandKey("-c");
+
+        //Assert
+        var actual = current.Equals(other);
+
+        //Assert
+        actual.Should().BeTrue();
+    }
+    #endregion IEquatable<CommandKey>.Equals
+
+    #region IEquatable<CommandKey>.Equals(Object? obj)
+    [Fact]
+    public void ReturnsFalse_WhenObjectIsNull()
+    {
+        //Arrange
+        var obj = (Object?)null;
+        var current = new CommandKey("-c");
+
+        //Act
+        var actual = current.Equals(obj);
+
+        //Assert
+        actual.Should().BeFalse();
+    }
+
+    [Fact]
+    public void ReturnsFalse_WhenObjectIsNotNullButIsNotOfTypeCommandKey()
+    {
+        //Arrange
+        var obj = (Object?)CommandArgument.Create("-c", "fake-filepath");
+        var current = new CommandKey("-c");
+
+        //Act
+        var actual = current.Equals(obj);
+
+        //Assert
+        actual.Should().BeFalse();
+    }
+
+    [Fact]
+    public void ReturnsFalse_WhenObjectIsNotNullAndIsOfTypeCommandKeyButNotEqualToTheCurrentInstance()
+    {
+        //Arrange
+        var obj = (Object?)new CommandKey("-w");
+        var current = new CommandKey("-c");
+
+        //Act
+        var actual = current.Equals(obj);
+
+        //Assert
+        actual.Should().BeFalse();
+    }
+
+    [Fact]
+    public void ReturnsTrue_WhenObjectIsNotNullAndIsOfTypeCommandKeyAndIsEqualToTheCurrentInstance()
+    {
+        //Arrange
+        var obj = (Object?)new CommandKey("-c");
+        var current = new CommandKey("-c");
+
+        //Act
+        var actual = current.Equals(obj);
+
+        //Assert
+        actual.Should().BeTrue();
+    }
+
+    #endregion IEquatable<CommandKey>.Equals(Object? obj)
+
+    #region == Operator
+    [Fact]
+    public void ReturnsFalse_WhenOperandLeftIsNull()
+    {
+        //Arrange
+        var left = (CommandKey)null!;
+        var right = new CommandKey("-c");
+
+        //Act
+        var actual = left == right;
+
+        //Assert
+        actual.Should().BeFalse();
+    }
+
+    [Fact]
+    public void ReturnsFalse_WhenOperandRightIsNull()
+    {
+        //Arrange
+        var left = new CommandKey("-c");
+        var right = (CommandKey)null!;
+
+        //Act
+        var actual = left == right;
+
+        //Assert
+        actual.Should().BeFalse();
+    }
+
+    [Fact]
+    public void ReturnsFalse_WhenOperandsAreNotNullAndNotEqual()
+    {
+        //Arrange
+        var left = new CommandKey("-c");
+        var right = new CommandKey("-w");
+
+        //Act
+        var actual = left == right;
+
+        //Assert
+        actual.Should().BeFalse();
+    }
+
+    [Fact]
+    public void ReturnsTrue_WhenOperandsAreNull()
+    {
+        //Arrange
+        var left = (CommandKey)null!;
+        var right = (CommandKey)null!;
+
+        //Act
+        var actual = left == right;
+
+        //Assert
+        actual.Should().BeTrue();
+    }
+
+    [Fact]
+    public void ReturnsTrue_WhenOperandsAreNotNullAndEqual()
+    {
+        //Arrange
+        var left = new CommandKey("-c");
+        var right = new CommandKey("-c");
+
+        //Act
+        var actual = left == right;
+
+        //Assert
+        actual.Should().BeTrue();
+    }
+    #endregion == Operator
+}

--- a/test/WCNet/Unit/CommandModels/CommandKeyTests/GetHashCode.cs
+++ b/test/WCNet/Unit/CommandModels/CommandKeyTests/GetHashCode.cs
@@ -1,0 +1,49 @@
+﻿namespace VP.CodingChallenge.WCNet.Test.Unit.CommandModels.CommandKeyTests;
+
+public class GetHashCode
+{
+    [Fact]
+    public void ReturnsSameValue_WhenSameInstanceIsCalledMultipleTimes()
+    {
+        //Arrange
+        var key = new CommandKey("-c");
+        var hash_1 = key.GetHashCode();
+        var hash_2 = key.GetHashCode();
+
+        //Act
+        var actual = hash_1.Equals(hash_2);
+
+        //Assert
+        actual.Should().BeTrue();
+    }
+
+    [Fact]
+    public void ReturnsSameValue_ForDifferentInstancesWhenTheyAreEqual()
+    {
+        //Arrange
+        var key_1 = new CommandKey("-c");
+        var key_2 = new CommandKey("-c");
+
+        //Act
+        var hash_1 = key_1.GetHashCode();
+        var hash_2 = key_2.GetHashCode();
+
+        //Assert
+        hash_1.Should().Be(hash_2);
+    }
+
+    [Fact]
+    public void ReturnsDifferentValue_ForDifferentInstancesWhenTheyAreNotEqual()
+    {
+        //Arrange
+        var key_1 = new CommandKey("-c");
+        var key_2 = new CommandKey("-w");
+
+        //Act
+        var hash_1 = key_1.GetHashCode();
+        var hash_2 = key_2.GetHashCode();
+
+        //Assert
+        hash_1.Should().NotBe(hash_2);
+    }
+}

--- a/test/WCNet/Unit/CommandModels/CommandKeyTests/NotEquals.cs
+++ b/test/WCNet/Unit/CommandModels/CommandKeyTests/NotEquals.cs
@@ -1,0 +1,32 @@
+﻿namespace VP.CodingChallenge.WCNet.Test.Unit.CommandModels.CommandKeyTests;
+
+public class NotEquals
+{
+    [Fact]
+    public void ReturnsFalse_WhenInstancesAreEqual()
+    {
+        //Arrange
+        var left = new CommandKey("-c");
+        var right = new CommandKey("-c");
+
+        //Act
+        var actual = left != right;
+
+        //Assert
+        actual.Should().BeFalse();
+    }
+
+    [Fact]
+    public void ReturnsTrue_WhenInstancesAreNotEqual()
+    {
+        //Arrange
+        var left = new CommandKey("-c");
+        var right = new CommandKey("-w");
+
+        //Act
+        var actual = left != right;
+
+        //Assert
+        actual.Should().BeTrue();
+    }
+}

--- a/test/WCNet/Unit/CommandModels/CommandKeyTests/ToString.cs
+++ b/test/WCNet/Unit/CommandModels/CommandKeyTests/ToString.cs
@@ -1,0 +1,18 @@
+﻿namespace VP.CodingChallenge.WCNet.Test.Unit.CommandModels.CommandKeyTests;
+
+public class ToString
+{
+    [Fact]
+    public void ReturnsStringContainingCommandKeyAndFilepath()
+    {
+        //Arrange
+        var commandKey = new CommandKey("-c");
+        var expected = "-c";
+
+        //Act
+        var actual = commandKey.ToString();
+
+        //Assert
+        actual.Should().Be(expected);
+    }
+}

--- a/test/WCNet/Unit/CommandModels/MessageTests/Equals.cs
+++ b/test/WCNet/Unit/CommandModels/MessageTests/Equals.cs
@@ -1,0 +1,165 @@
+﻿namespace VP.CodingChallenge.WCNet.Test.Unit.CommandModels.MessageTests;
+
+public class Equals
+{
+    #region IEquatable<Message>.Equals
+    [Fact]
+    public void ReturnsFalse_WhenInstancesAreNotEqual()
+    {
+        //Arrange
+        var other = new Message("test message");
+        var current = new Message("message");
+
+        //Assert
+        var actual = current.Equals(other);
+
+        //Assert
+        actual.Should().BeFalse();
+    }
+
+    [Fact]
+    public void ReturnsTrue_WhenInstancesAreEqual()
+    {
+        //Arrange
+        var other = new Message("message");
+        var current = new Message("message");
+
+        //Assert
+        var actual = current.Equals(other);
+
+        //Assert
+        actual.Should().BeTrue();
+    }
+    #endregion IEquatable<Message>.Equals
+
+    #region IEquatable<Message>.Equals(Object? obj)
+    [Fact]
+    public void ReturnsFalse_WhenObjectIsNull()
+    {
+        //Arrange
+        var obj = (Object?)null;
+        var current = new Message("message");
+
+        //Act
+        var actual = current.Equals(obj);
+
+        //Assert
+        actual.Should().BeFalse();
+    }
+
+    [Fact]
+    public void ReturnsFalse_WhenObjectIsNotNullButIsNotOfTypeMessage()
+    {
+        //Arrange
+        var obj = (Object?)CommandArgument.Create("-c", "fake-filepath");
+        var current = new Message("message");
+
+        //Act
+        var actual = current.Equals(obj);
+
+        //Assert
+        actual.Should().BeFalse();
+    }
+
+    [Fact]
+    public void ReturnsFalse_WhenObjectIsNotNullAndIsOfTypeMessageButNotEqualToTheCurrentInstance()
+    {
+        //Arrange
+        var obj = (Object?)new Message("test message");
+        var current = new Message("message");
+
+        //Act
+        var actual = current.Equals(obj);
+
+        //Assert
+        actual.Should().BeFalse();
+    }
+
+    [Fact]
+    public void ReturnsTrue_WhenObjectIsNotNullAndIsOfTypeMessageAndIsEqualToTheCurrentInstance()
+    {
+        //Arrange
+        var obj = (Object?)new Message("message");
+        var current = new Message("message");
+
+        //Act
+        var actual = current.Equals(obj);
+
+        //Assert
+        actual.Should().BeTrue();
+    }
+
+    #endregion IEquatable<Message>.Equals(Object? obj)
+
+    #region == Operator
+    [Fact]
+    public void ReturnsFalse_WhenOperandLeftIsNull()
+    {
+        //Arrange
+        var left = (Message)null!;
+        var right = new Message("message");
+
+        //Act
+        var actual = left == right;
+
+        //Assert
+        actual.Should().BeFalse();
+    }
+
+    [Fact]
+    public void ReturnsFalse_WhenOperandRightIsNull()
+    {
+        //Arrange
+        var left = new Message("message");
+        var right = (Message)null!;
+
+        //Act
+        var actual = left == right;
+
+        //Assert
+        actual.Should().BeFalse();
+    }
+
+    [Fact]
+    public void ReturnsFalse_WhenOperandsAreNotEqual()
+    {
+        //Arrange
+        var left = new Message("message");
+        var right = new Message("test message");
+
+        //Act
+        var actual = left == right;
+
+        //Assert
+        actual.Should().BeFalse();
+    }
+
+    [Fact]
+    public void ReturnsTrue_WhenOperandsAreNull()
+    {
+        //Arrange
+        var left = (Message)null!;
+        var right = (Message)null!;
+
+        //Act
+        var actual = left == right;
+
+        //Assert
+        actual.Should().BeTrue();
+    }
+
+    [Fact]
+    public void ReturnsTrue_WhenOperandsAreNotNullAndEqual()
+    {
+        //Arrange
+        var left = new Message("message");
+        var right = new Message("message");
+
+        //Act
+        var actual = left == right;
+
+        //Assert
+        actual.Should().BeTrue();
+    }
+    #endregion == Operator
+}

--- a/test/WCNet/Unit/CommandModels/MessageTests/GetHashCode.cs
+++ b/test/WCNet/Unit/CommandModels/MessageTests/GetHashCode.cs
@@ -1,0 +1,49 @@
+﻿namespace VP.CodingChallenge.WCNet.Test.Unit.CommandModels.MessageTests;
+
+public class GetHashCode
+{
+    [Fact]
+    public void ReturnsSameValue_WhenSameInstanceIsCalledMultipleTimes()
+    {
+        //Arrange
+        var key = new Message("message");
+        var hash_1 = key.GetHashCode();
+        var hash_2 = key.GetHashCode();
+
+        //Act
+        var actual = hash_1.Equals(hash_2);
+
+        //Assert
+        actual.Should().BeTrue();
+    }
+
+    [Fact]
+    public void ReturnsSameValue_ForDifferentInstancesWhenTheyAreEqual()
+    {
+        //Arrange
+        var key_1 = new Message("message");
+        var key_2 = new Message("message");
+
+        //Act
+        var hash_1 = key_1.GetHashCode();
+        var hash_2 = key_2.GetHashCode();
+
+        //Assert
+        hash_1.Should().Be(hash_2);
+    }
+
+    [Fact]
+    public void ReturnsDifferentValue_ForDifferentInstancesWhenTheyAreNotEqual()
+    {
+        //Arrange
+        var key_1 = new Message("message");
+        var key_2 = new Message("test message");
+
+        //Act
+        var hash_1 = key_1.GetHashCode();
+        var hash_2 = key_2.GetHashCode();
+
+        //Assert
+        hash_1.Should().NotBe(hash_2);
+    }
+}

--- a/test/WCNet/Unit/CommandModels/MessageTests/NotEquals.cs
+++ b/test/WCNet/Unit/CommandModels/MessageTests/NotEquals.cs
@@ -1,0 +1,32 @@
+﻿namespace VP.CodingChallenge.WCNet.Test.Unit.CommandModels.MessageTests;
+
+public class NotEquals
+{
+    [Fact]
+    public void ReturnsFalse_WhenInstancesAreEqual()
+    {
+        //Arrange
+        var left = new Message("message");
+        var right = new Message("message");
+
+        //Act
+        var actual = left != right;
+
+        //Assert
+        actual.Should().BeFalse();
+    }
+
+    [Fact]
+    public void ReturnsTrue_WhenInstancesAreNotEqual()
+    {
+        //Arrange
+        var left = new Message("message");
+        var right = new Message("test message");
+
+        //Act
+        var actual = left != right;
+
+        //Assert
+        actual.Should().BeTrue();
+    }
+}

--- a/test/WCNet/Unit/CommandModels/MessageTests/ToString.cs
+++ b/test/WCNet/Unit/CommandModels/MessageTests/ToString.cs
@@ -1,0 +1,18 @@
+﻿namespace VP.CodingChallenge.WCNet.Test.Unit.CommandModels.MessageTests;
+
+public class ToString
+{
+    [Fact]
+    public void ReturnsStringContainingCommandKeyAndFilepath()
+    {
+        //Arrange
+        var commandKey = new Message("message");
+        var expected = "message";
+
+        //Act
+        var actual = commandKey.ToString();
+
+        //Assert
+        actual.Should().Be(expected);
+    }
+}

--- a/test/WCNet/Unit/CommandParsers/DefaultCommandParserTests/Parse.cs
+++ b/test/WCNet/Unit/CommandParsers/DefaultCommandParserTests/Parse.cs
@@ -55,7 +55,7 @@ public class Parse
 		actualResult.Should().NotBeNull().And.BeOfType<Result<CommandArgument>>();
 		actualResult.IsFailed.Should().BeTrue();
 		actualResult.Error.Should().NotBeNull().And.BeOfType<CommandNotFoundError>();
-		actualResult.Error.Message.Should().NotBeNullOrEmpty().And.Be("Command: -w not found.");
+		actualResult.Error.Message.Should().NotBeNullOrEmpty().And.Be("Command: \"-w\" not found.");
 	}
 
 	[Fact]
@@ -80,7 +80,7 @@ public class Parse
 		actualResult.Should().NotBeNull().And.BeOfType<Result<CommandArgument>>();
 		actualResult.IsFailed.Should().BeTrue();
 		actualResult.Error.Should().NotBeNull().And.BeOfType<FileExtensionNotAllowedError>();
-		actualResult.Error.Message.Should().NotBeNullOrEmpty().And.Be($"File extension: .{fileExtension}, is not allowed.");
+		actualResult.Error.Message.Should().NotBeNullOrEmpty().And.Be($"File extension: \".{fileExtension}\", is not allowed.");
 	}
 
 	[Fact]

--- a/test/WCNet/Usings.cs
+++ b/test/WCNet/Usings.cs
@@ -1,8 +1,10 @@
 ﻿global using FluentAssertions;
 global using LightResults;
 global using Microsoft.Extensions.Options;
+global using Microsoft.VisualStudio.TestPlatform.Utilities;
 global using NSubstitute;
 global using VP.CodingChallenge.WCNet.CommandErrors;
+global using VP.CodingChallenge.WCNet.CommandHandlers;
 global using VP.CodingChallenge.WCNet.CommandModels;
 global using VP.CodingChallenge.WCNet.CommandParsers;
 global using VP.CodingChallenge.WCNet.CommandResolvers;


### PR DESCRIPTION
# Changes

## Added
- `CommandExecutionError` class.
- `WcNetConfigurationExtension` class.
- Unit test cases for `CommandHandlerBase.Main` method.
- Unit test cases for class: `CommandArgument` and struct: `CommandKey` and `Message`.

## Modified
- By overriding `ToString()` in `CommandErrors`.
- By adding `try-catch` block in `Main` method.
- By adding comments to `CommandModels`.