### PR TITLE
removed '-' from command key

### DIFF
--- a/src/WCNet/CommandParsers/DefaultCommandParser.cs
+++ b/src/WCNet/CommandParsers/DefaultCommandParser.cs
@@ -35,7 +35,9 @@ internal class DefaultCommandParser : ICommandParser
 			return Result<CommandArgument>.Fail(FileNotFoundError.Create(filename));
 		}
 
-		return Result<CommandArgument>.Ok(CommandArgument.Create(commandValue, filepath));
+        commandValue = commandValue.Replace("-", "");
+
+        return Result<CommandArgument>.Ok(CommandArgument.Create(commandValue, filepath));
 	}
 
 	#region Private Methods

--- a/src/WCNet/Commands/Concrete/ByteCountCommand.cs
+++ b/src/WCNet/Commands/Concrete/ByteCountCommand.cs
@@ -1,6 +1,6 @@
 ﻿namespace VP.CodingChallenge.WCNet.Commands.Concrete;
 
-[CommandKey("-c")]
+[CommandKey("c")]
 internal class ByteCountCommand : ICommand
 {
 	public String Execute(String filepath)

--- a/src/WCNet/Commands/Concrete/LineCountCommand.cs
+++ b/src/WCNet/Commands/Concrete/LineCountCommand.cs
@@ -1,6 +1,6 @@
 ﻿namespace VP.CodingChallenge.WCNet.Commands.Concrete;
 
-[CommandKey("-l")]
+[CommandKey("l")]
 internal class LineCountCommand : ICommand
 {
 	public String Execute(String filepath)

--- a/test/WCNet/IntegrationTests/WCNetIntegrationTests.cs
+++ b/test/WCNet/IntegrationTests/WCNetIntegrationTests.cs
@@ -19,8 +19,8 @@ public class WCNetIntegrationTests : IClassFixture<FilesDirectoryFixture>
 
         //add commands
         services
-            .AddKeyedScoped<ICommand, ByteCountCommand>("-c")
-            .AddKeyedScoped<ICommand, LineCountCommand>("-l");
+            .AddKeyedScoped<ICommand, ByteCountCommand>("c")
+            .AddKeyedScoped<ICommand, LineCountCommand>("l");
 
         //add command resolvers
         services
@@ -28,8 +28,8 @@ public class WCNetIntegrationTests : IClassFixture<FilesDirectoryFixture>
             {
                 var commandMap = new Dictionary<CommandKey, ICommand>
                 {
-                    { "-c", provider.GetRequiredKeyedService<ICommand>("-c") },
-                    { "-l", provider.GetRequiredKeyedService<ICommand>("-l" ) }
+                    { "c", provider.GetRequiredKeyedService<ICommand>("c") },
+                    { "l", provider.GetRequiredKeyedService<ICommand>("l" ) }
                 };
 
                 return new DefaultCommandResolver(commandMap);
@@ -56,8 +56,10 @@ public class WCNetIntegrationTests : IClassFixture<FilesDirectoryFixture>
     {
         //Arrange
         var commandHandler = _serviceProvider.GetRequiredService<CommandHandlerBase>();
-        var filepath = CreateTestFile("byte_count_testfile.txt", "Hello World!\r\nThis is byte count integration test.");
-        var args = new String[] { "-c", "byte_count_testfile.txt" };
+        var filename = "byte_count_testfile.txt";
+        var commandKey = (CommandKey)"c";
+        var filepath = CreateTestFile(filename, "Hello World!\r\nThis is byte count integration test.");
+        var args = new String[] { "-c", filename };
         var expected = "50 byte_count_testfile.txt";
 
         //Act
@@ -74,8 +76,10 @@ public class WCNetIntegrationTests : IClassFixture<FilesDirectoryFixture>
     {
         //Arrange
         var commandHandler = _serviceProvider.GetRequiredService<CommandHandlerBase>();
-        var filepath = CreateTestFile("line_count_testfile.txt", "Line1\r\nLine2\r\nLine3\r\nLine4.");
-        var args = new String[] { "-l", "line_count_testfile.txt" };
+        var filename = "line_count_testfile.txt";
+        var commandKey = (CommandKey)"l";
+        var filepath = CreateTestFile(filename, "Line1\r\nLine2\r\nLine3\r\nLine4.");
+        var args = new String[] { "-l", filename };
         var expected = "4 line_count_testfile.txt";
 
         //Act

--- a/test/WCNet/UnitTests/CommandParsers/DefaultCommandParserTests/Parse.cs
+++ b/test/WCNet/UnitTests/CommandParsers/DefaultCommandParserTests/Parse.cs
@@ -113,19 +113,19 @@ public class Parse
     {
         //Arrange
         var tempPath = Path.GetTempPath();
-        var filePath = CreateTestFile("testfile.txt", "Line1\nLine2\nLine3");
-        var args = new String[] { "-c", "testfile.txt" };
-        var filename = args[1];
-        var mockedOptions = Substitute.For<IOptions<ParserOptions>>();
-        mockedOptions.Value.Returns(new ParserOptions
+        var command = "c";
+        var filename = "testfile.txt";
+        var args = new String[] { "-c", filename };
+        var stubOptions = Substitute.For<IOptions<ParserOptions>>();
+        stubOptions.Value.Returns(new ParserOptions
         {
             CommandExpression = "^(-[cl])",
             AllowedFileExtension = ".txt",
             Directory = tempPath
         });
 
-        var parser = new DefaultCommandParser(mockedOptions);
-        var expectedResult = CommandArgument.Create(args[0], Path.Combine(tempPath, args[1]));
+        var parser = new DefaultCommandParser(stubOptions);
+        var expectedResult = CommandArgument.Create(command, Path.Combine(tempPath, filename));
 
         //Act
         var actualResult = parser.Parse(args);
@@ -136,14 +136,4 @@ public class Parse
         actualResult.IsSuccess.Should().BeTrue();
         actualResult.Value.Should().Be(expectedResult);
     }
-
-    #region Private Methods
-    private String CreateTestFile(String filename, String content)
-    {
-        var filepath = Path.Combine(Path.GetTempPath(), filename);
-        File.WriteAllText(filepath, content);
-
-        return filepath;
-    }
-    #endregion Private Methods
 }


### PR DESCRIPTION
# Changes
- removed the need to use `-` while declaring in the `CommandKeyAttribute`.
- updated unit and integration test cases to incorporate the first point.
- removed unused methods and code statements from `DefaultCommandParserTests`.
