### PR TITLE
character count command

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ The key objectives of this project are (for more details visit [here](https://co
 - [FluentAssertions](https://fluentassertions.com/)
 
 ## Features
-### Source
+### Source Code
   - [x] **Byte count (`-c`)**: Counts the number of bytes in a file.
   - [x] **Line count (`-l`)**: Counts the number of lines in a file.
   - [ ] **Word count (`-w`)**: Counts the number of words in a file.
@@ -60,4 +60,33 @@ vp-coding-challenge-wcnet/
 
 ## How to?
 ### Add a new command
-### Register a new command
+- Create a class in **Commands > Concrete** directory/folder, with prefix `Command` and add `CommandKeyAttribute` to it.
+  ```
+  [CommandKey("x")]
+  internal sealed class TestCommand : ICommand
+  {
+  	public String Execute (String filepath) => throw new NotImplementedException();
+  }
+  ```
+- Add the same command-key (`x` in this case) in `ParserOptions` of `appsettings.json` as follows:
+  ```
+  //before
+  {
+  	"ParserOptions": {
+    	"CommandExpression": "^(-[clwm])"
+  	}
+	}
+
+  //after
+  {
+  	"ParserOptions": {
+  		"CommandExpression": "^(-[clwmx])"
+  	}
+  }
+  ```
+### Run your newly added command
+- Modify `launchSettings.json` as follows:
+  ```
+  "commandLineArgs": "-<your_command-key> <filename>.txt"
+  ```
+- Build and run the application.

--- a/src/WCNet/Attributes/CommandKeyAttribute.cs
+++ b/src/WCNet/Attributes/CommandKeyAttribute.cs
@@ -2,9 +2,14 @@
 
 internal sealed class CommandKeyAttribute : Attribute
 {
-	public String Key { get; }
+	public CommandKey Key { get; }
 
-	public CommandKeyAttribute(String key)
+    public CommandKeyAttribute(String key)
+        : this((CommandKey)key)
+    {
+    }
+
+	public CommandKeyAttribute(CommandKey key)
 	{
 		Key = key;
 	}

--- a/src/WCNet/CommandModels/CommandKey.cs
+++ b/src/WCNet/CommandModels/CommandKey.cs
@@ -66,4 +66,13 @@ public readonly struct CommandKey : IEquatable<CommandKey>
     /// <param name="right">The <see cref="CommandKey"/> instance on the right</param>
     /// <returns>True if the two specified <see cref="CommandKey"/> instances are not equal; otherwise, false.</returns>
     public static Boolean operator !=(CommandKey left, CommandKey right) => !left.Equals(right);
+
+    public Boolean IsByteCountKey() => IsOrdinalIgnoreCaseComparisonEqual("c");
+    public Boolean IsCharacterCountKey() => IsOrdinalIgnoreCaseComparisonEqual("m");
+    public Boolean IsLineCountKey() => IsOrdinalIgnoreCaseComparisonEqual("l");
+    public Boolean IsWordCountKey() => IsOrdinalIgnoreCaseComparisonEqual("w");
+
+    #region Private Methods
+    private Boolean IsOrdinalIgnoreCaseComparisonEqual(String key) => Value.Equals(key, StringComparison.OrdinalIgnoreCase);
+    #endregion Private Methods
 }

--- a/src/WCNet/Commands/Concrete/CharacterCountCommand.cs
+++ b/src/WCNet/Commands/Concrete/CharacterCountCommand.cs
@@ -1,0 +1,20 @@
+﻿namespace VP.CodingChallenge.WCNet.Commands.Concrete;
+
+[CommandKey("m")]
+internal class CharacterCountCommand : ICommand
+{
+    public String Execute(String filepath)
+    {
+        var fileInfo = new FileInfo(filepath);
+        var characterCount = 0UL;
+        using var streamReader = new StreamReader(fileInfo.FullName);
+        var line = streamReader.ReadLine();
+        while (line != null)
+        {
+            characterCount += (UInt64)line.Length;
+            line = streamReader.ReadLine();
+        }
+
+        return $"{characterCount} {Path.GetFileName(filepath)}";
+    }
+}

--- a/src/WCNet/Startup/WcNetServiceExtension.cs
+++ b/src/WCNet/Startup/WcNetServiceExtension.cs
@@ -2,96 +2,125 @@
 
 internal static class WCNetServiceExtension
 {
-	private readonly static Type _iCommandType = typeof(ICommand);
-	private static List<Type> _concreteCommandTypes = [];
-	private static List<String> _allowedCommands = [];
+    private readonly static Type _iCommandType = typeof(ICommand);
+    private static List<Type> _concreteCommandTypes = [];
+    private static List<String> _allowedCommands = [];
 
-	internal static IServiceProvider BuildWCNetServiceProvider(this IServiceCollection services, IConfiguration configuration)
-	{
-		InitializeConcreteCommandTypes();
-		InitializeAllowedCommands();
+    internal static IServiceProvider BuildWCNetServiceProvider(this IServiceCollection services, IConfiguration configuration)
+    {
+        InitializeConcreteCommandTypes();
+        InitializeAllowedCommands();
 
-		return services.AddWCNet(configuration).BuildServiceProvider();
-	}
+        return services.AddWCNet(configuration).BuildServiceProvider();
+    }
 
-	private static IServiceCollection AddWCNet(this IServiceCollection services, IConfiguration configuration)
-		=> services
-			.AddWCNetCommands()
-			.AddWCNetCommandResolver()
-			.AddWCNetCommandParser(configuration)
-			.AddWCNetCommandHandler();
+    private static IServiceCollection AddWCNet(this IServiceCollection services, IConfiguration configuration)
+        => services
+            .AddWCNetCommands()
+            .AddWCNetCommandResolver()
+            .AddWCNetCommandParser(configuration)
+            .AddWCNetCommandHandler();
 
-	private static IServiceCollection AddWCNetCommands(this IServiceCollection services)
-	{
-		if (_concreteCommandTypes.Count == 0)
-		{
-			//need to log the error
-			return services;
-		}
+    private static IServiceCollection AddWCNetCommands(this IServiceCollection services)
+    {
+        if (_concreteCommandTypes.Count == 0)
+        {
+            Console.WriteLine("No commands found to register.");
+            return services;
+        }
 
-		foreach (var commandType in _concreteCommandTypes)
-		{
-			var keyAttribute = commandType.GetCustomAttribute<CommandKeyAttribute>();
-			if (keyAttribute is null) continue;
+        foreach (var commandType in _concreteCommandTypes)
+        {
+            RegisterCommand(services, commandType);
+        }
 
-			services.AddKeyedScoped(_iCommandType, keyAttribute.Key, commandType);
-		}
+        return services;
+    }
 
-		return services;
-	}
+    private static IServiceCollection AddWCNetCommandResolver(this IServiceCollection services)
+        => services.AddScoped<ICommandResolver, DefaultCommandResolver>(provider =>
+            {
+                var commandMap = new Dictionary<CommandKey, ICommand>(_concreteCommandTypes.Count);
+                foreach (var commandType in _concreteCommandTypes)
+                {
+                    var attribute = commandType.GetCustomAttribute<CommandKeyAttribute>();
+                    if (attribute is null) continue;
 
-	private static IServiceCollection AddWCNetCommandResolver(this IServiceCollection services)
-		=> services.AddScoped<ICommandResolver, DefaultCommandResolver>(provider =>
-			{
-				var commandMap = new Dictionary<CommandKey, ICommand>(_concreteCommandTypes.Count);
-				foreach (var commandType in _concreteCommandTypes)
-				{
-					var attribute = commandType.GetCustomAttribute<CommandKeyAttribute>();
-					if (attribute is null) continue;
+                    var commandInstance = provider.GetRequiredKeyedService<ICommand>(attribute.Key);
+                    commandMap[attribute.Key] = commandInstance;
+                }
 
-					var commandInstance = provider.GetRequiredKeyedService<ICommand>(attribute.Key);
-					commandMap[attribute.Key] = commandInstance;
-				}
+                return new DefaultCommandResolver(commandMap);
+            });
 
-				return new DefaultCommandResolver(commandMap);
-			});
+    private static IServiceCollection AddWCNetCommandParser(this IServiceCollection services, IConfiguration configuration)
+    {
+        services.AddScoped<ICommandParser, DefaultCommandParser>();
 
-	private static IServiceCollection AddWCNetCommandParser(this IServiceCollection services, IConfiguration configuration)
-	{
-		services.AddScoped<ICommandParser, DefaultCommandParser>();
+        var section = configuration.GetSection(nameof(ParserOptions));
+        if (section is null)
+        {
+            return services;
+        }
 
-		var section = configuration.GetSection(nameof(ParserOptions));
-		if (section is null)
-		{
-			return services;
-		}
+        return services.Configure<ParserOptions>(section);
+    }
 
-		return services.Configure<ParserOptions>(section);
-	}
+    private static IServiceCollection AddWCNetCommandHandler(this IServiceCollection services)
+        => services.AddScoped<CommandHandlerBase, DefaultCommandHandler>();
 
-	private static IServiceCollection AddWCNetCommandHandler(this IServiceCollection services)
-		=> services.AddScoped<CommandHandlerBase, DefaultCommandHandler>();
+    private static void RegisterCommand(IServiceCollection services, Type commandType)
+    {
+        var attribute = commandType.GetCustomAttribute<CommandKeyAttribute>();
+        if (attribute is null)
+        {
+            //Console.WriteLine($"Skipping registration for {commandType.Name}: No CommandKeyAttribute found.");
+            return;
+        }
 
-	private static void InitializeConcreteCommandTypes()
-	{
-		_concreteCommandTypes = Assembly
-			.GetExecutingAssembly()
-			.GetTypes()
-			.Where(type => _iCommandType.IsAssignableFrom(type) && type.IsClass && !type.IsAbstract)
-			.ToList();
-	}
-	private static void InitializeAllowedCommands()
-	{
-		_allowedCommands = new List<String>(_concreteCommandTypes.Count);
-		foreach (var type in _concreteCommandTypes)
-		{
-			var attribute = type.GetCustomAttribute<CommandKeyAttribute>();
-			if (attribute is null)
-			{
-				continue;
-			}
+        //register non-character count command
+        if (!attribute.Key.IsCharacterCountKey())
+        {
+            services.AddKeyedScoped(_iCommandType, attribute.Key, commandType);
+            return;
+        }
 
-			_allowedCommands.Add(attribute.Key);
-		}
-	}
+        RegisterCharacterCountCommand(services, attribute.Key);
+    }
+
+    private static void RegisterCharacterCountCommand(IServiceCollection services, CommandKey key)
+    {
+        //register ByteCountCommand for single-byte encoding
+        if (Encoding.Default.IsSingleByte)
+        {
+            services.AddKeyedScoped<ICommand, ByteCountCommand>(key);
+            return;
+        }
+
+        //register CharacterCountCommand for multibyte encoding
+        services.AddKeyedScoped<ICommand, CharacterCountCommand>(key);
+    }
+
+    private static void InitializeConcreteCommandTypes()
+    {
+        _concreteCommandTypes = Assembly
+            .GetExecutingAssembly()
+            .GetTypes()
+            .Where(type => _iCommandType.IsAssignableFrom(type) && type.IsClass && !type.IsAbstract)
+            .ToList();
+    }
+    private static void InitializeAllowedCommands()
+    {
+        _allowedCommands = new List<String>(_concreteCommandTypes.Count);
+        foreach (var type in _concreteCommandTypes)
+        {
+            var attribute = type.GetCustomAttribute<CommandKeyAttribute>();
+            if (attribute is null)
+            {
+                continue;
+            }
+
+            _allowedCommands.Add(attribute.Key);
+        }
+    }
 }

--- a/src/WCNet/Usings.cs
+++ b/src/WCNet/Usings.cs
@@ -4,6 +4,7 @@ global using Microsoft.Extensions.DependencyInjection;
 global using Microsoft.Extensions.Options;
 global using System.Reflection;
 global using System.Runtime.CompilerServices;
+global using System.Text;
 global using System.Text.RegularExpressions;
 global using VP.CodingChallenge.WCNet.Attributes;
 global using VP.CodingChallenge.WCNet.CommandErrors;

--- a/src/WCNet/appsettings.json
+++ b/src/WCNet/appsettings.json
@@ -8,7 +8,7 @@
   "ParserOptions": {
     "Directory": ".\\Files",
     "AllowedFileExtension": ".txt",
-    "CommandExpression": "^(-[clw])",
+    "CommandExpression": "^(-[clwm])",
     "FilenameExpression": "[\\w\\-.]+\\.[\\w]+$"
   }
 }


### PR DESCRIPTION
# Changes
- Added `CharacterCountCommand` - it returns character-count if locale supports multibytes; otherwise, byte-count.
- Added "m" to command-expression in `appsettings.json`.
- Added **Add a new command** and **Run your newly added command** sections to README.md.
- Added helper methods to struct `CommandKey`.
- Added new constructor to `CommandKeyAttribute` and type for property `Key` has been changed from `String` to `CommandKey`.
- Modified `WCNetServiceExtension` class.