### PR TITLE
handle default commands

### DIFF
--- a/src/WCNet/CommandHandlers/CommandHandlerBase.cs
+++ b/src/WCNet/CommandHandlers/CommandHandlerBase.cs
@@ -8,7 +8,7 @@ public abstract class CommandHandlerBase
 
     public void Main(String[] args)
     {
-        var commandKey = new CommandKey();
+        CommandKey[] keys = [];
 
         try
         {
@@ -19,7 +19,7 @@ public abstract class CommandHandlerBase
                 return;
             }
 
-            commandKey = argumentResult.Value.CommandKey;
+            keys = argumentResult.Value.CommandKeys;
             var messageResult = Handle(argumentResult.Value);
             if (messageResult.IsFailed)
             {
@@ -31,7 +31,7 @@ public abstract class CommandHandlerBase
         }
         catch (Exception ex)
         {
-            Console.WriteLine($"Error executing command: {commandKey}: {ex.Message}");
+            Console.WriteLine($"Error executing command: {String.Join(',', keys)}: {ex.Message}");
         }
     }
 }

--- a/src/WCNet/CommandHandlers/DefaultCommandHandler.cs
+++ b/src/WCNet/CommandHandlers/DefaultCommandHandler.cs
@@ -13,11 +13,18 @@ internal class DefaultCommandHandler : CommandHandlerBase
 
     protected override Result<Message> Handle(CommandArgument commandArgument)
 	{
-        var command = _commandResolver.Resolve(commandArgument.CommandKey);
-        var filename = Path.GetFileName(commandArgument.Filepath);
-        var countResult = command.Execute(commandArgument.Filepath);
+        var countResults = new List<Result<UInt64>>(commandArgument.CommandKeys.Length);
+        foreach (var key in commandArgument.CommandKeys)
+        {
+            var command = _commandResolver.Resolve(key);
+            var result = command.Execute(commandArgument.Filepath);
+            countResults.Add(result);
+        }
 
-        return Result<Message>.Ok($"{countResult.Value} {filename}");
+        var filename = Path.GetFileName(commandArgument.Filepath);
+        var countText = String.Join(' ', countResults.Select(r => r.Value));
+
+        return Result<Message>.Ok($"{countText} {filename}");
 	}
 
     protected override Result PostHandle(Message message)
@@ -25,5 +32,6 @@ internal class DefaultCommandHandler : CommandHandlerBase
         Console.WriteLine(message);
         return Result.Ok();
     }
+
     protected override Result<CommandArgument> PreHandle(String[] args) => _commandParser.Parse(args);
 }

--- a/src/WCNet/CommandModels/CommandArgument.cs
+++ b/src/WCNet/CommandModels/CommandArgument.cs
@@ -8,7 +8,7 @@ public class CommandArgument : IEquatable<CommandArgument>
     /// <summary>
     /// Gets the <see cref="CommandModels.CommandKey"/>
     /// </summary>
-	public CommandKey CommandKey { get; }
+	public CommandKey[] CommandKeys { get; }
 
     /// <summary>
     /// Gets the Filepath
@@ -18,21 +18,21 @@ public class CommandArgument : IEquatable<CommandArgument>
     /// <summary>
     /// Initializes a new instance of <see cref="CommandArgument"/>.
     /// </summary>
-    /// <param name="commandKey">The <see cref="CommandModels.CommandKey"/></param>
+    /// <param name="commandKeys">The <see cref="CommandKey"/></param>
     /// <param name="filepath">The filepath</param>
-	private CommandArgument(CommandKey commandKey, String filepath)
+	private CommandArgument(CommandKey[] commandKeys, String filepath)
 	{
-		CommandKey = commandKey;
+		CommandKeys = commandKeys;
 		Filepath = filepath;
 	}
 
     /// <summary>
     /// Creates a new instance of <see cref="CommandArgument"/>.
     /// </summary>
-    /// <param name="commandKey">The <see cref="CommandModels.CommandKey"/></param>
+    /// <param name="CommandKeys">The <see cref="CommandKey"/></param>
     /// <param name="filepath">The filepath</param>
     /// <returns>An instance of <see cref="CommandArgument"/>.</returns>
-	public static CommandArgument Create(CommandKey commandKey, String filepath) => new CommandArgument(commandKey, filepath);
+	public static CommandArgument Create(CommandKey[] commandKeys, String filepath) => new CommandArgument(commandKeys, filepath);
 
     /// <summary>
     /// Determines whether the <paramref name="other"/> (<see cref="CommandArgument"/>) is equal to the current <see cref="CommandArgument"/>.
@@ -52,13 +52,16 @@ public class CommandArgument : IEquatable<CommandArgument>
     /// Gets the hash code for the <see cref="CommandArgument"/>.
     /// </summary>
     /// <returns>A hash code for the current <see cref="CommandArgument"/>.</returns>
-	public override Int32 GetHashCode() => HashCode.Combine(CommandKey, Filepath);
+	public override Int32 GetHashCode()
+        => HashCode.Combine(
+            CommandKeys.Aggregate(0, (hash, key) => hash ^ key.GetHashCode()),
+            Filepath.GetHashCode());
 
     /// <summary>
     /// Gets the string representation of <see cref="CommandArgument"/>.
     /// </summary>
     /// <returns>The string representation of <see cref="CommandArgument"/>.</returns>
-	public override String ToString() => $"Command: {CommandKey}, Filename: \"{Path.GetFileName(Filepath)}\"";
+	public override String ToString() => $"Command: {CommandKeys}, Filename: \"{Path.GetFileName(Filepath)}\"";
 
     /// <summary>
     /// Determines whether two specified <see cref="CommandArgument"/> instances are equal.
@@ -73,12 +76,12 @@ public class CommandArgument : IEquatable<CommandArgument>
 			return true;
 		}
 
-		if (left is null || right is null)
+		if (left is null || right is null || !left.CommandKeys.SequenceEqual(right.CommandKeys))
 		{
 			return false;
 		}
 
-		return left.CommandKey.Equals(right.CommandKey) && String.Equals(left.Filepath, right.Filepath);
+		return String.Equals(left.Filepath, right.Filepath, StringComparison.Ordinal);
 	}
 
     /// <summary>

--- a/src/WCNet/CommandParsers/DefaultCommandParser.cs
+++ b/src/WCNet/CommandParsers/DefaultCommandParser.cs
@@ -2,48 +2,79 @@
 
 internal class DefaultCommandParser : ICommandParser
 {
-	private readonly ParserOptions _options;
+    private readonly ParserOptions _options;
 
-	public DefaultCommandParser(IOptions<ParserOptions> options)
-	{
-		_options = options.Value;
-	}
+    public DefaultCommandParser(IOptions<ParserOptions> options)
+    {
+        _options = options.Value;
+    }
 
-	public Result<CommandArgument> Parse(String[] args)
-	{
-		if (args.Length != 2)
-		{
+    public Result<CommandArgument> Parse(String[] args)
+    {
+        if (HasUnexpectedNumberOfItems(args))
+        {
             return Result<CommandArgument>.Fail(CommandFormatError.Create());
-		}
+        }
 
-		var commandRegex = new Regex(_options.CommandExpression);
-		var commandValue = args[0];
-		if (!commandRegex.IsMatch(commandValue))
-		{
-			return Result<CommandArgument>.Fail(CommandNotFoundError.Create(commandValue));
-		}
+        if (HasSingleItem(args))
+        {
+            return ParseToDefaultCommands(args);
+        }
 
-		var filename = args[^1];
-		if (!IsFileExtensionAllowed(filename))
-		{
-			return Result<CommandArgument>.Fail(FileExtensionNotAllowedError.Create(Path.GetExtension(filename)));
-		}
+        return ParseToSpecifiedCommands(args);
+    }
 
-		var filepath = Path.Combine(_options.Directory, filename);
-		if (FileDoesNotExists(filepath))
-		{
-			return Result<CommandArgument>.Fail(FileNotFoundError.Create(filename));
-		}
+    #region Private Methods
+    private Result<CommandArgument> ParseToDefaultCommands(String[] args)
+    {
+        var filename = args[^1];
+        var filepath = Path.Combine(_options.Directory, filename);
+        if (!IsFileExtensionAllowed(filename))
+        {
+            return Result<CommandArgument>.Fail(FileExtensionNotAllowedError.Create(Path.GetExtension(filename)));
+        }
 
-        commandValue = commandValue.Replace("-", "");
+        if (FileDoesNotExists(filepath))
+        {
+            return Result<CommandArgument>.Fail(FileNotFoundError.Create(filename));
+        }
 
-        return Result<CommandArgument>.Ok(CommandArgument.Create(commandValue, filepath));
-	}
+        return Result<CommandArgument>.Ok(CommandArgument.Create(_options.DefaultCommands, filepath));
+    }
 
-	#region Private Methods
-	private static Boolean FileDoesNotExists(String filepath)
-		=> !File.Exists(filepath);
-	private Boolean IsFileExtensionAllowed(String filename)
-		=> _options.AllowedFileExtension.Equals(Path.GetExtension(filename));
-	#endregion Private Methods
+    private Result<CommandArgument> ParseToSpecifiedCommands(String[] args)
+    {
+        var commandRegex = new Regex(_options.CommandExpression);
+        var commandValue = args[0];
+        if (!commandRegex.IsMatch(commandValue))
+        {
+            return Result<CommandArgument>.Fail(CommandNotFoundError.Create(commandValue));
+        }
+
+        var filename = args[^1];
+        if (!IsFileExtensionAllowed(filename))
+        {
+            return Result<CommandArgument>.Fail(FileExtensionNotAllowedError.Create(Path.GetExtension(filename)));
+        }
+
+        var filepath = Path.Combine(_options.Directory, filename);
+        if (FileDoesNotExists(filepath))
+        {
+            return Result<CommandArgument>.Fail(FileNotFoundError.Create(filename));
+        }
+
+        var keys = new CommandKey[] { commandValue.Replace("-", "") };
+        return Result<CommandArgument>.Ok(CommandArgument.Create(keys, filepath));
+    }
+
+    private static Boolean HasUnexpectedNumberOfItems(String[] args)
+        => args.Length < 1 || args.Length > 2;
+    private static Boolean HasSingleItem(String[] args)
+        => args.Length == 1;
+
+    private static Boolean FileDoesNotExists(String filepath)
+        => !File.Exists(filepath);
+    private Boolean IsFileExtensionAllowed(String filename)
+        => _options.AllowedFileExtension.Equals(Path.GetExtension(filename));
+    #endregion Private Methods
 }

--- a/src/WCNet/Configurations/ParserOptions.cs
+++ b/src/WCNet/Configurations/ParserOptions.cs
@@ -2,7 +2,11 @@
 
 public class ParserOptions
 {
-	public String CommandExpression { get; set; } = String.Empty;
-	public String Directory { get; set; } = String.Empty;
-	public String AllowedFileExtension { get; set; } = String.Empty;
+    public String AllowedFileExtension { get; set; } = String.Empty;
+    public String CommandExpression { get; set; } = String.Empty;
+    public CommandKey[] DefaultCommands { get; set; } = [];
+    public String Directory { get; set; } = String.Empty;
+
+    [JsonIgnore]
+    public String[] DefaultCommandsRaw { get; set; } = [];
 }

--- a/src/WCNet/Properties/launchSettings.json
+++ b/src/WCNet/Properties/launchSettings.json
@@ -2,7 +2,7 @@
   "profiles": {
     "VP.CodingChallenge.WCNet": {
       "commandName": "Project",
-      "commandLineArgs": "-c test.txt"
+      "commandLineArgs": "test.txt"
     }
   }
 }

--- a/src/WCNet/Startup/WcNetServiceExtension.cs
+++ b/src/WCNet/Startup/WcNetServiceExtension.cs
@@ -54,16 +54,27 @@ internal static class WCNetServiceExtension
             });
 
     private static IServiceCollection AddWCNetCommandParser(this IServiceCollection services, IConfiguration configuration)
-    {
-        services.AddScoped<ICommandParser, DefaultCommandParser>();
+        => services
+            .AddScoped<ICommandParser, DefaultCommandParser>()
+            .AddWcNetParserOptions (configuration);
 
+    private static IServiceCollection AddWcNetParserOptions(this IServiceCollection services, IConfiguration configuration)
+    {
         var section = configuration.GetSection(nameof(ParserOptions));
         if (section is null)
         {
             return services;
         }
 
-        return services.Configure<ParserOptions>(section);
+        return services
+            .Configure<ParserOptions>(section)
+            .PostConfigure<ParserOptions>(options =>
+            {
+                if (options.DefaultCommandsRaw is not null && options.DefaultCommandsRaw.Length > 0)
+                {
+                    options.DefaultCommands = options.DefaultCommandsRaw.Select(dc => new CommandKey(dc)).ToArray();
+                }
+            });
     }
 
     private static IServiceCollection AddWCNetCommandHandler(this IServiceCollection services)

--- a/src/WCNet/Usings.cs
+++ b/src/WCNet/Usings.cs
@@ -5,6 +5,7 @@ global using Microsoft.Extensions.Options;
 global using System.Reflection;
 global using System.Runtime.CompilerServices;
 global using System.Text;
+global using System.Text.Json.Serialization;
 global using System.Text.RegularExpressions;
 global using VP.CodingChallenge.WCNet.Attributes;
 global using VP.CodingChallenge.WCNet.CommandErrors;

--- a/src/WCNet/appsettings.json
+++ b/src/WCNet/appsettings.json
@@ -6,9 +6,9 @@
     }
   },
   "ParserOptions": {
-    "Directory": ".\\Files",
     "AllowedFileExtension": ".txt",
     "CommandExpression": "^(-[clwm])",
-    "FilenameExpression": "[\\w\\-.]+\\.[\\w]+$"
+    "DefaultCommandsRaw": ["l", "w", "c"],
+    "Directory": ".\\Files"
   }
 }

--- a/test/WCNet/UnitTests/CommandHandlers/CommandHandlerBaseTests/Main.cs
+++ b/test/WCNet/UnitTests/CommandHandlers/CommandHandlerBaseTests/Main.cs
@@ -33,7 +33,7 @@ public class Main
         var commandKey = new CommandKey("-w");
         var args = new String[] { "-c", "filename.txt" };
         var preHandleResult = Result<CommandArgument>.Fail(CommandNotFoundError.Create(commandKey));
-        var commandArgs = CommandArgument.Create(commandKey, "filename.txt");
+        var commandArgs = CommandArgument.Create([commandKey], "filename.txt");
         var messageResult = Result<Message>.Ok(new Message("Success"));
         var message = messageResult.Value;
         var testHandler = new TestCommandHandler(
@@ -57,7 +57,7 @@ public class Main
         //Arrange
         var commandKey = new CommandKey("-c");
         var args = new String[] { "-c", "filename.txt" };
-        var commandArgs = CommandArgument.Create(commandKey, "filename.txt");
+        var commandArgs = CommandArgument.Create([commandKey], "filename.txt");
         var preHandleResult = Result<CommandArgument>.Ok(commandArgs);
         var message = new Message("Success");
         var messageResult = Result<Message>.Fail(CommandExecutionError.Create(commandKey));
@@ -82,7 +82,7 @@ public class Main
         //Arrange
         var commandKey = new CommandKey("-c");
         var args = new String[] { "-c", "filename.txt" };
-        var commandArgs = CommandArgument.Create(commandKey, "filename.txt");
+        var commandArgs = CommandArgument.Create([commandKey], "filename.txt");
         var preHandleResult = Result<CommandArgument>.Ok(commandArgs);
         var message = new Message("342190 filename.txt");
         var messageResult = Result<Message>.Ok(message);

--- a/test/WCNet/UnitTests/CommandModels/CommandArgumentTests/Equals.cs
+++ b/test/WCNet/UnitTests/CommandModels/CommandArgumentTests/Equals.cs
@@ -7,8 +7,8 @@ public class Equals
     public void ReturnsFalse_WhenInstancesAreNotEqual()
     {
         //Arrange
-        var other = CommandArgument.Create("-c", "filepath");
-        var current = CommandArgument.Create("-c", "fake-filepath");
+        var other = CommandArgument.Create(["c"], "filepath");
+        var current = CommandArgument.Create(["c"], "fake-filepath");
 
         //Assert
         var actual = current.Equals(other);
@@ -21,8 +21,8 @@ public class Equals
     public void ReturnsTrue_WhenInstancesAreEqual()
     {
         //Arrange
-        var other = CommandArgument.Create("-c", "filepath");
-        var current = CommandArgument.Create("-c", "filepath");
+        var other = CommandArgument.Create(["c"], "filepath");
+        var current = CommandArgument.Create(["c"], "filepath");
 
         //Assert
         var actual = current.Equals(other);
@@ -38,7 +38,7 @@ public class Equals
     {
         //Arrange
         var obj = (Object?)null;
-        var current = CommandArgument.Create("-c", "filepath");
+        var current = CommandArgument.Create(["c"], "filepath");
 
         //Act
         var actual = current.Equals(obj);
@@ -52,7 +52,7 @@ public class Equals
     {
         //Arrange
         var obj = (Object?)new CommandKey("-c");
-        var current = CommandArgument.Create("-c", "filepath");
+        var current = CommandArgument.Create(["c"], "filepath");
 
         //Act
         var actual = current.Equals(obj);
@@ -65,8 +65,8 @@ public class Equals
     public void ReturnsFalse_WhenObjectIsOfTypeCommandArgumentButOneOfThePropertiesDoesNotMatch()
     {
         //Arrange
-        var obj = (Object?)CommandArgument.Create("-c", "fake-filepath");
-        var current = CommandArgument.Create("-c", "filepath");
+        var obj = (Object?)CommandArgument.Create(["c"], "fake-filepath");
+        var current = CommandArgument.Create(["c"], "filepath");
 
         //Act
         var actual = current.Equals(obj);
@@ -79,8 +79,8 @@ public class Equals
     public void ReturnsTrue_WhenObjectIsOfTypeCommandArgumentAndAllThePropertiesMatch()
     {
         //Arrange
-        var obj = (Object?)CommandArgument.Create("-c", "filepath");
-        var current = CommandArgument.Create("-c", "filepath");
+        var obj = (Object?)CommandArgument.Create(["c"], "filepath");
+        var current = CommandArgument.Create(["c"], "filepath");
 
         //Act
         var actual = current.Equals(obj);
@@ -97,7 +97,7 @@ public class Equals
     {
         //Arrange
         var left = (CommandArgument)null!;
-        var right = CommandArgument.Create("-c", "filepath");
+        var right = CommandArgument.Create(["c"], "filepath");
 
         //Act
         var actual = left == right;
@@ -110,7 +110,7 @@ public class Equals
     public void ReturnsFalse_WhenOperandRightIsNull()
     {
         //Arrange
-        var left = CommandArgument.Create("-c", "filepath");
+        var left = CommandArgument.Create(["c"], "filepath");
         var right = (CommandArgument)null!;
 
         //Act
@@ -124,8 +124,8 @@ public class Equals
     public void ReturnsFalse_WhenCommandKeyMatchesButFilepathDoesNot()
     {
         //Arrange
-        var left = CommandArgument.Create("-c", "filepath");
-        var right = CommandArgument.Create("-c", "fake-filepath");
+        var left = CommandArgument.Create(["c"], "filepath");
+        var right = CommandArgument.Create(["c"], "fake-filepath");
 
         //Act
         var actual = left == right;
@@ -138,8 +138,8 @@ public class Equals
     public void ReturnsFalse_WhenFilepathMatchesButCommandKeyDoesNot()
     {
         //Arrange
-        var left = CommandArgument.Create("-c", "filepath");
-        var right = CommandArgument.Create("-w", "filepath");
+        var left = CommandArgument.Create(["c"], "filepath");
+        var right = CommandArgument.Create(["w"], "filepath");
 
         //Act
         var actual = left == right;
@@ -166,8 +166,8 @@ public class Equals
     public void ReturnsTrue_WhenOperandsBothCommandKeyAndFilepathAreEqual()
     {
         //Arrange
-        var left = CommandArgument.Create("-c", "filepath");
-        var right = CommandArgument.Create("-c", "filepath");
+        var left = CommandArgument.Create(["c"], "filepath");
+        var right = CommandArgument.Create(["c"], "filepath");
 
         //Act
         var actual = left == right;

--- a/test/WCNet/UnitTests/CommandModels/CommandArgumentTests/GetHashCode.cs
+++ b/test/WCNet/UnitTests/CommandModels/CommandArgumentTests/GetHashCode.cs
@@ -6,7 +6,7 @@ public class GetHashCode
     public void ReturnsSameValue_WhenSameObjectIsCalledMultipleTimes()
     {
         //Arrange
-        var commandArgs = CommandArgument.Create("-c", "filepath");
+        var commandArgs = CommandArgument.Create(["c"], "filepath");
         var hash_1 = commandArgs.GetHashCode();
         var hash_2 = commandArgs.GetHashCode();
 
@@ -21,8 +21,8 @@ public class GetHashCode
     public void ReturnsSameValue_ForEqualObjects()
     {
         //Arrange
-        var commandArgs_1 = CommandArgument.Create("-c", "filepath");
-        var commandArgs_2 = CommandArgument.Create("-c", "filepath");
+        var commandArgs_1 = CommandArgument.Create(["c"], "filepath");
+        var commandArgs_2 = CommandArgument.Create(["c"], "filepath");
 
         //Act
         var hash_1 = commandArgs_1.GetHashCode();
@@ -36,8 +36,8 @@ public class GetHashCode
     public void ReturnsDifferentValue_WhenCommandKeyMatchesButFilepathDoesNotMatch()
     {
         //Arrange
-        var commandArgs_1 = CommandArgument.Create("-c", "filepath");
-        var commandArgs_2 = CommandArgument.Create("-c", "fake-filepath");
+        var commandArgs_1 = CommandArgument.Create(["c"], "filepath");
+        var commandArgs_2 = CommandArgument.Create(["c"], "fake-filepath");
 
         //Act
         var hash_1 = commandArgs_1.GetHashCode();
@@ -51,8 +51,8 @@ public class GetHashCode
     public void ReturnsDifferentValue_WhenFilepathMatchesButCommandKeyDoesNotMatch()
     {
         //Arrange
-        var commandArgs_1 = CommandArgument.Create("-c", "filepath");
-        var commandArgs_2 = CommandArgument.Create("-l", "filepath");
+        var commandArgs_1 = CommandArgument.Create(["c"], "filepath");
+        var commandArgs_2 = CommandArgument.Create(["l"], "filepath");
 
         //Act
         var hash_1 = commandArgs_1.GetHashCode();

--- a/test/WCNet/UnitTests/CommandModels/CommandArgumentTests/NotEquals.cs
+++ b/test/WCNet/UnitTests/CommandModels/CommandArgumentTests/NotEquals.cs
@@ -6,8 +6,8 @@ public class NotEquals
     public void ReturnsFalse_WhenInstancesAreEqual()
     {
         //Arrange
-        var left = CommandArgument.Create("-c", "filepath");
-        var right = CommandArgument.Create("-c", "filepath");
+        var left = CommandArgument.Create(["c"], "filepath");
+        var right = CommandArgument.Create(["c"], "filepath");
 
         //Act
         var actual = left != right;
@@ -20,8 +20,8 @@ public class NotEquals
     public void ReturnsTrue_WhenInstancesAreNotEqual()
     {
         //Arrange
-        var left = CommandArgument.Create("-c", "filepath");
-        var right = CommandArgument.Create("-c", "fake-filepath");
+        var left = CommandArgument.Create(["c"], "filepath");
+        var right = CommandArgument.Create(["c"], "fake-filepath");
 
         //Act
         var actual = left != right;

--- a/test/WCNet/UnitTests/CommandModels/CommandArgumentTests/ToString.cs
+++ b/test/WCNet/UnitTests/CommandModels/CommandArgumentTests/ToString.cs
@@ -6,11 +6,11 @@ public class ToString
     public void ReturnsStringContainingCommandKeyAndFilepath()
     {
         //Arrange
-        var commandKey = new CommandKey("-c");
+        var commandKeys = new CommandKey[] { "-c" };
         var filename = "filename.txt";
         var filepath = Path.Combine($".\\filepath\\{filename}");
-        var commandArgs = CommandArgument.Create(commandKey, filepath);
-        var expected = $"Command: {commandKey}, Filename: \"{filename}\"";
+        var commandArgs = CommandArgument.Create(commandKeys, filepath);
+        var expected = $"Command: {commandKeys}, Filename: \"{filename}\"";
 
         //Act
         var actual = commandArgs.ToString();

--- a/test/WCNet/UnitTests/CommandModels/CommandKeyTests/Equals.cs
+++ b/test/WCNet/UnitTests/CommandModels/CommandKeyTests/Equals.cs
@@ -7,8 +7,8 @@ public class Equals
     public void ReturnsFalse_WhenInstancesAreNotEqual()
     {
         //Arrange
-        var other = new CommandKey("-c");
-        var current = new CommandKey("-w");
+        var other = new CommandKey("c");
+        var current = new CommandKey("w");
 
         //Assert
         var actual = current.Equals(other);
@@ -21,8 +21,8 @@ public class Equals
     public void ReturnsTrue_WhenInstancesAreEqual()
     {
         //Arrange
-        var other = new CommandKey("-c");
-        var current = new CommandKey("-c");
+        var other = new CommandKey("c");
+        var current = new CommandKey("c");
 
         //Assert
         var actual = current.Equals(other);
@@ -38,7 +38,7 @@ public class Equals
     {
         //Arrange
         var obj = (Object?)null;
-        var current = new CommandKey("-c");
+        var current = new CommandKey("c");
 
         //Act
         var actual = current.Equals(obj);
@@ -51,8 +51,8 @@ public class Equals
     public void ReturnsFalse_WhenObjectIsNotNullButIsNotOfTypeCommandKey()
     {
         //Arrange
-        var obj = (Object?)CommandArgument.Create("-c", "fake-filepath");
-        var current = new CommandKey("-c");
+        var obj = (Object?)CommandArgument.Create(["c"], "fake-filepath");
+        var current = new CommandKey("c");
 
         //Act
         var actual = current.Equals(obj);
@@ -65,8 +65,8 @@ public class Equals
     public void ReturnsFalse_WhenObjectIsNotNullAndIsOfTypeCommandKeyButNotEqualToTheCurrentInstance()
     {
         //Arrange
-        var obj = (Object?)new CommandKey("-w");
-        var current = new CommandKey("-c");
+        var obj = (Object?)new CommandKey("w");
+        var current = new CommandKey("c");
 
         //Act
         var actual = current.Equals(obj);
@@ -79,8 +79,8 @@ public class Equals
     public void ReturnsTrue_WhenObjectIsNotNullAndIsOfTypeCommandKeyAndIsEqualToTheCurrentInstance()
     {
         //Arrange
-        var obj = (Object?)new CommandKey("-c");
-        var current = new CommandKey("-c");
+        var obj = (Object?)new CommandKey("c");
+        var current = new CommandKey("c");
 
         //Act
         var actual = current.Equals(obj);
@@ -97,7 +97,7 @@ public class Equals
     {
         //Arrange
         var left = (CommandKey)null!;
-        var right = new CommandKey("-c");
+        var right = new CommandKey("c");
 
         //Act
         var actual = left == right;
@@ -110,7 +110,7 @@ public class Equals
     public void ReturnsFalse_WhenOperandRightIsNull()
     {
         //Arrange
-        var left = new CommandKey("-c");
+        var left = new CommandKey("c");
         var right = (CommandKey)null!;
 
         //Act
@@ -124,8 +124,8 @@ public class Equals
     public void ReturnsFalse_WhenOperandsAreNotNullAndNotEqual()
     {
         //Arrange
-        var left = new CommandKey("-c");
-        var right = new CommandKey("-w");
+        var left = new CommandKey("c");
+        var right = new CommandKey("w");
 
         //Act
         var actual = left == right;
@@ -152,8 +152,8 @@ public class Equals
     public void ReturnsTrue_WhenOperandsAreNotNullAndEqual()
     {
         //Arrange
-        var left = new CommandKey("-c");
-        var right = new CommandKey("-c");
+        var left = new CommandKey("c");
+        var right = new CommandKey("c");
 
         //Act
         var actual = left == right;

--- a/test/WCNet/UnitTests/CommandModels/MessageTests/Equals.cs
+++ b/test/WCNet/UnitTests/CommandModels/MessageTests/Equals.cs
@@ -51,7 +51,7 @@ public class Equals
     public void ReturnsFalse_WhenObjectIsNotNullButIsNotOfTypeMessage()
     {
         //Arrange
-        var obj = (Object?)CommandArgument.Create("-c", "fake-filepath");
+        var obj = (Object?)CommandArgument.Create(["c"], "fake-filepath");
         var current = new Message("message");
 
         //Act

--- a/test/WCNet/UnitTests/CommandParsers/DefaultCommandParserTests/Parse.cs
+++ b/test/WCNet/UnitTests/CommandParsers/DefaultCommandParserTests/Parse.cs
@@ -2,11 +2,12 @@
 
 public class Parse
 {
+    #region Failure Cases
     [Fact]
-    public void FailsWithCommandFormatError_WhenNumberOfArgumentsIsLessThanTwo()
+    public void FailsWithCommandFormatError_WhenArgumentArrayIsEmpty()
     {
         //Arrange
-        var args = new String[] { "filename.txt" };
+        var args = Array.Empty<String>();
         var mockedOptions = Substitute.For<IOptions<ParserOptions>>();
         var parser = new DefaultCommandParser(mockedOptions);
 
@@ -21,7 +22,7 @@ public class Parse
     }
 
     [Fact]
-    public void FailsWithCommandFormatError_WhenNumberOfArgumentsIsGreaterThanTwo()
+    public void FailsWithCommandFormatError_WhenArgumentArrayHasMoreThanTwoItems()
     {
         //Arrange
         var args = new String[] { "-c", "", "filename.txt" };
@@ -39,7 +40,55 @@ public class Parse
     }
 
     [Fact]
-    public void FailsWithCommandNotFoundError_WhenSpecifiedCommandIsNotFound()
+    public void FailsWithFileExtensionNotAllowedError_WhenFilenameIsTheOnlyItemInTheArgumentArray_AndItsExtensionIsNotAllowed()
+    {
+        //Arrange
+        var args = new String[] { "filename.exe" };
+        var fileExtension = Path.GetExtension(args[^1]);
+        var mockedOptions = Substitute.For<IOptions<ParserOptions>>();
+        mockedOptions.Value.Returns(new ParserOptions
+        {
+            AllowedFileExtension = ".txt"
+        });
+
+        var parser = new DefaultCommandParser(mockedOptions);
+
+        //Act
+        var actualResult = parser.Parse(args);
+
+        //Assert
+        actualResult.Should().NotBeNull().And.BeOfType<Result<CommandArgument>>();
+        actualResult.IsFailed.Should().BeTrue();
+        actualResult.Error.Should().NotBeNull().And.BeOfType<FileExtensionNotAllowedError>();
+        actualResult.Error.Message.Should().NotBeNullOrEmpty().And.Be($"File extension: \".{fileExtension}\", is not allowed.");
+    }
+
+    [Fact]
+    public void FailsWithFileNotFounError_WhenFilenameIsTheOnlyItemInTheArgumentArray_AndItDoesNotExists()
+    {
+        //Arrange
+        var args = new String[] { "filename.txt" };
+        var filename = args[^1];
+        var mockedOptions = Substitute.For<IOptions<ParserOptions>>();
+        mockedOptions.Value.Returns(new ParserOptions
+        {
+            AllowedFileExtension = ".txt"
+        });
+
+        var parser = new DefaultCommandParser(mockedOptions);
+
+        //Act
+        var actualResult = parser.Parse(args);
+
+        //Assert
+        actualResult.Should().NotBeNull().And.BeOfType<Result<CommandArgument>>();
+        actualResult.IsFailed.Should().BeTrue();
+        actualResult.Error.Should().NotBeNull().And.BeOfType<FileNotFoundError>();
+        actualResult.Error.Message.Should().NotBeNullOrEmpty().And.Be($"File: {filename}, not found.");
+    }
+
+    [Fact]
+    public void FailsWithCommandNotFoundError_WhenArgumentArrayHasCommandAndFilename_AndCommandDoesNotExists()
     {
         //Arrange
         var args = new String[] { "-w", "filename.txt" };
@@ -59,7 +108,7 @@ public class Parse
     }
 
     [Fact]
-    public void FailsWithFilesExtensionNotAllowedError_WhenSpecifiedFilenameHasIncorrectExtension()
+    public void FailsWithFileExtensionNotAllowedError_WhenArgumentArrayHasCommandAndFilename_AndFileExtensionIsNotAllowed()
     {
         //Arrange
         var args = new String[] { "-c", "filename.exe" };
@@ -84,7 +133,7 @@ public class Parse
     }
 
     [Fact]
-    public void FailsWithFileNotFoundError_WhenSpecifiedFileDoesNotExist()
+    public void FailsWithFileNotFoundError_WhenArgumentArrayHasCommandAndFilename_AndFileDoesNotExists()
     {
         //Arrange
         var args = new String[] { "-c", "filename.txt" };
@@ -107,13 +156,45 @@ public class Parse
         actualResult.Error.Should().NotBeNull().And.BeOfType<FileNotFoundError>();
         actualResult.Error.Message.Should().NotBeNullOrEmpty().And.Be($"File: {filename}, not found.");
     }
+    #endregion Failure Cases
 
+    #region Success Cases
     [Fact]
-    public void ReturnsCommandArgumentResult_WhenBothCommandAndFilenameAreSuccessfullyParsed()
+    public void SuccessfullyReturnsInstanceOfCommandArgumentWithDefaultCommands_WhenFilenameIsTheOnlyItemInTheArgumentArray()
     {
         //Arrange
         var tempPath = Path.GetTempPath();
-        var command = "c";
+        var filename = "testfile.txt";
+        var args = new String[] { filename };
+        var stubOptions = Substitute.For<IOptions<ParserOptions>>();
+        var parserOptions = new ParserOptions
+        {
+            DefaultCommands = ["l", "w", "c"],
+            CommandExpression = "^(-[cl])",
+            AllowedFileExtension = ".txt",
+            Directory = tempPath
+        };
+        stubOptions.Value.Returns(parserOptions);
+
+        var parser = new DefaultCommandParser(stubOptions);
+        var expectedResult = CommandArgument.Create(parserOptions.DefaultCommands, Path.Combine(tempPath, filename));
+
+        //Act
+        var actualResult = parser.Parse(args);
+
+        //Assert
+        actualResult.Should().NotBeNull().And.BeOfType<Result<CommandArgument>>();
+        actualResult.Errors.Should().BeEmpty();
+        actualResult.IsSuccess.Should().BeTrue();
+        actualResult.Value.Should().Be(expectedResult);
+    }
+
+    [Fact]
+    public void SuccessfullyReturnsInstanceOfCommandArgumentWithSpecifiedCommand_WhenArgumentArrayHasCorrectCommandAndFilename()
+    {
+        //Arrange
+        var tempPath = Path.GetTempPath();
+        var commandKey = "c";
         var filename = "testfile.txt";
         var args = new String[] { "-c", filename };
         var stubOptions = Substitute.For<IOptions<ParserOptions>>();
@@ -125,7 +206,7 @@ public class Parse
         });
 
         var parser = new DefaultCommandParser(stubOptions);
-        var expectedResult = CommandArgument.Create(command, Path.Combine(tempPath, filename));
+        var expectedResult = CommandArgument.Create([commandKey], Path.Combine(tempPath, filename));
 
         //Act
         var actualResult = parser.Parse(args);
@@ -136,4 +217,5 @@ public class Parse
         actualResult.IsSuccess.Should().BeTrue();
         actualResult.Value.Should().Be(expectedResult);
     }
+    #endregion Success Cases
 }


### PR DESCRIPTION
# Changes
- Modified CommandHandler to handle default commands.
- Modified `CommandArgument` to handle array of `CommandKey`.
- Modified `DefaultCommandParser` to handle default commands.
- Modified `PaserOptions` to handle default commands.
- Modified `WcNetServiceExtension` to configure `DefaultCommands` property in `ParserOptions`.
- Modified test cases to cater default command changes.