### PR TITLE
Changed return type of Execute method of ICommand

### DIFF
--- a/src/WCNet/Attributes/CommandKeyAttribute.cs
+++ b/src/WCNet/Attributes/CommandKeyAttribute.cs
@@ -1,16 +1,12 @@
 ﻿namespace VP.CodingChallenge.WCNet.Attributes;
 
-internal sealed class CommandKeyAttribute : Attribute
+[AttributeUsage(AttributeTargets.Class, AllowMultiple = false, Inherited = false)]
+internal sealed class CommandKeyAttribute(Command key) : Attribute
 {
-	public Command Key { get; }
+    public Command Key { get; } = key;
 
     public CommandKeyAttribute(String key)
         : this((Command)key)
     {
     }
-
-	public CommandKeyAttribute(Command key)
-	{
-		Key = key;
-	}
 }

--- a/src/WCNet/CommandErrors/CommandNotSetError.cs
+++ b/src/WCNet/CommandErrors/CommandNotSetError.cs
@@ -1,0 +1,16 @@
+﻿namespace VP.CodingChallenge.WCNet.CommandErrors;
+
+internal class CommandNotSetError : Error
+{
+    private readonly String _message;
+
+    private CommandNotSetError(String message)
+        : base(message)
+    {
+        _message = message;
+    }
+
+    internal static CommandNotSetError Create() => new CommandNotSetError($"Command is not set. First set command and try again.");
+
+    public override String ToString() => _message;
+}

--- a/src/WCNet/CommandFactories/CountCommandFactory.cs
+++ b/src/WCNet/CommandFactories/CountCommandFactory.cs
@@ -3,23 +3,20 @@
 internal class CountCommandFactory : ICommandFactory
 {
     private readonly IDictionary<Command, Type> _commandTypeMap;
-    private readonly IOutput _output;
 
-    public CountCommandFactory(
-        IDictionary<Command, Type> commandTypeMap,
-        IOutput output)
+    public CountCommandFactory(IDictionary<Command, Type> commandTypeMap)
     {
         _commandTypeMap = commandTypeMap;
-        _output = output;
     }
 
     public ICommand CreateCommand(CommandRequest request)
     {
         if (_commandTypeMap.TryGetValue(request.CommandKey, out var commandType))
         {
-            return (ICommand?)Activator.CreateInstance(commandType, request.Filepath, _output) ?? new CommandNotFound(_output);
+            var command = (ICommand?)Activator.CreateInstance(commandType, request.Filepath) ?? new CommandNotFound();
+            return command;
         }
 
-        return new CommandNotFound(_output);
+        return new CommandNotFound();
     }
 }

--- a/src/WCNet/CommandHandlers/CommandHandlerBase.cs
+++ b/src/WCNet/CommandHandlers/CommandHandlerBase.cs
@@ -18,7 +18,7 @@ public abstract class CommandHandlerBase
         PostHandle(messageResult.Value);
     }
 
-    internal void Usage()
+    internal static void Usage()
     {
         Console.WriteLine("Usage: wc.NET [OPTIONS] [FILE]");
         Console.WriteLine("Counts lines, characters, words, and bytes in the specified FILE.");

--- a/src/WCNet/CommandHandlers/DefaultCommandHandler.cs
+++ b/src/WCNet/CommandHandlers/DefaultCommandHandler.cs
@@ -1,6 +1,6 @@
 ﻿namespace VP.CodingChallenge.WCNet.CommandHandlers;
 
-internal class DefaultCommandHandler : CommandHandlerBase
+internal class DefaultCommandHandler
 {
     private readonly ICommandResolver _commandResolver;
     private readonly ICommandInvoker _invoker;
@@ -11,18 +11,71 @@ internal class DefaultCommandHandler : CommandHandlerBase
         _invoker = invoker;
 	}
 
-    protected override Result<Message> Handle(CommandRequest request)
+    internal void Main(CommandRequest request)
+    {
+        var messageResult = Handle(request);
+        if (messageResult.IsFailed)
+        {
+            Console.WriteLine(messageResult.Error);
+            Usage();
+            return;
+        }
+
+        PostHandle(messageResult.Value);
+    }
+
+    private Result<Message> Handle(CommandRequest request)
 	{
         var command = _commandResolver.ResolveCommand(request);
         _invoker.SetCommand(command);
-        _invoker.InvokeCommand();
+        
+        var countResult = _invoker.InvokeCommand();
+        var messageResult = GetMessage(countResult, request.Filepath.Filename);
 
-        return Result<Message>.Ok($"Command executed successfully.");
+        return messageResult;
 	}
 
-    protected override Result PostHandle(Message message)
+    private static Result<Message> GetMessage(Result<Count> countResult, String filename)
+    {
+        if (countResult.IsFailed)
+        {
+            return Result<Message>.Fail(countResult.Error);
+        }
+
+        //var builder = new StringBuilder(countResult.Value.Count);
+        //foreach (var count in countResult.Value)
+        //{
+        //    builder.Append(count);
+        //    builder.Append(' ');
+        //}
+
+        //builder.Append(filename);
+        //return Result<Message>.Ok(builder);
+
+        var textToDisplay = $"{countResult.Value} {filename}";
+        return Result<Message>.Ok(textToDisplay);
+    }
+
+    private static Result PostHandle(Message message)
     {
         Console.WriteLine(message);
         return Result.Ok();
+    }
+
+    private static void Usage()
+    {
+        Console.WriteLine("Usage: wc.NET [OPTIONS] [FILE]");
+        Console.WriteLine("Counts lines, characters, words, and bytes in the specified FILE.");
+        Console.WriteLine();
+        Console.WriteLine("Options:");
+        Console.WriteLine("  -c,         Print the byte counts.");
+        Console.WriteLine("  -m,         Print the character counts.");
+        Console.WriteLine("  -l,         Print the line counts.");
+        Console.WriteLine("  -w,         Print the word counts.");
+        Console.WriteLine("              Display this help and exit.");
+        Console.WriteLine();
+        Console.WriteLine("Example:");
+        Console.WriteLine("  wc.NET -lwm filename.txt");
+        Console.WriteLine("  wc.NET --lines --words --chars filename.txt");
     }
 }

--- a/src/WCNet/CommandInvokers/DefaultCommandInvoker.cs
+++ b/src/WCNet/CommandInvokers/DefaultCommandInvoker.cs
@@ -4,14 +4,14 @@ internal class DefaultCommandInvoker : ICommandInvoker
 {
     private ICommand? _command = null;
 
-    public void InvokeCommand()
+    public Result<Count> InvokeCommand()
     {
         if (_command == null)
         {
-            throw new CommandNotSetException();
+            Result<Count>.Fail(CommandNotSetError.Create());
         }
 
-        _command.Execute();
+        return _command.Execute();
     }
     public void SetCommand(ICommand command) => _command = command;
 }

--- a/src/WCNet/CommandInvokers/ICommandInvoker.cs
+++ b/src/WCNet/CommandInvokers/ICommandInvoker.cs
@@ -3,5 +3,5 @@
 internal interface ICommandInvoker
 {
     void SetCommand(ICommand command);
-    void InvokeCommand();
+    Result<Count> InvokeCommand();
 }

--- a/src/WCNet/CommandModels/Count.cs
+++ b/src/WCNet/CommandModels/Count.cs
@@ -1,0 +1,28 @@
+﻿namespace VP.CodingChallenge.WCNet.CommandModels;
+
+internal readonly struct Count(Int64 value) : IEquatable<Count>
+{
+    internal Int64 Value { get; } = value;
+
+    public Boolean Equals(Count other) => Value == other.Value;
+
+    public override Boolean Equals(Object? obj) => obj is not null && obj is Count other && Equals(other);
+
+    public override Int32 GetHashCode() => Value.GetHashCode();
+
+    public override String ToString() => Value.ToString();
+
+    public static implicit operator Int64(Count count) => count.Value;
+
+    public static implicit operator Count(Int64 value) => new(value);
+
+    public static implicit operator Count(Int32 value) => new(value);
+
+    public static implicit operator Count(Int16 value) => new(value);
+
+    public static implicit operator Count(Byte value) => new(value);
+
+    public static Boolean operator ==(Count left, Count right) => left.Equals(right);
+
+    public static Boolean operator !=(Count left, Count right) => !left.Equals(right);
+}

--- a/src/WCNet/CommandModels/Filepath.cs
+++ b/src/WCNet/CommandModels/Filepath.cs
@@ -4,6 +4,7 @@ public readonly struct Filepath : IEquatable<Filepath>
     public static readonly Filepath Empty = String.Empty;
 
     public String Value { get; }
+    public String Filename => Path.GetFileName(Value);
 
     public Filepath(String value)
     {

--- a/src/WCNet/CommandModels/Message.cs
+++ b/src/WCNet/CommandModels/Message.cs
@@ -14,6 +14,7 @@ public readonly struct Message : IEquatable<Message>
     public override Int32 GetHashCode() => Text.GetHashCode();
     public override String ToString() => Text;
     public static implicit operator Message(String text) => new Message(text);
+    public static implicit operator Message(StringBuilder builder) => new Message(builder.ToString());
     public static implicit operator String(Message message) => message.Text;
     public static Boolean operator ==(Message left, Message right) => left.Equals(right);
     public static Boolean operator !=(Message left, Message right) => !left.Equals(right);

--- a/src/WCNet/CommandParsers/DefaultCommandParser.cs
+++ b/src/WCNet/CommandParsers/DefaultCommandParser.cs
@@ -7,7 +7,7 @@ internal class DefaultCommandParser
 
     public static Result<CommandRequest> Parse(String[] args, ParserOptions? options)
     {
-        if (IsIncorrectFormat(args))
+        if (IsIncorrectCommandFormat(args))
         {
             return Result<CommandRequest>.Fail(CommandFormatError.Create());
         }
@@ -18,7 +18,7 @@ internal class DefaultCommandParser
         }
 
         var filename = args[^1];
-        if (IsDefault(args))
+        if (IsDefaultCommand(args))
         {
             return ParseToDefaultCommands(options.DefaultCommands, options.Directory, filename, options.AllowedFileExtension);
         }
@@ -33,10 +33,10 @@ internal class DefaultCommandParser
         options.DefaultCommands.Length == 0 ||
         String.IsNullOrEmpty(options.AllowedCommandPattern) ||
         String.IsNullOrEmpty(options.AllowedFileExtension);
-    private static Boolean IsDefault(String[] args) => args.Length == 1;
-    private static Boolean IsExtensionNotAllowed(String current, String allowed)
+    private static Boolean IsDefaultCommand(String[] args) => args.Length == 1;
+    private static Boolean IsFileExtensionNotAllowed(String current, String allowed)
         => !String.Equals(current, allowed, StringComparison.OrdinalIgnoreCase);
-    private static Boolean IsIncorrectFormat([NotNullWhen(false)]String[] args)
+    private static Boolean IsIncorrectCommandFormat([NotNullWhen(false)]String[] args)
         => args is null ||
         args.Length < 1 ||
         args.Length > 2;
@@ -83,7 +83,7 @@ internal class DefaultCommandParser
     private static Result<Filepath> ValidateFilepath(String directory, String filename, String allowedExtension)
     {
         var extension = Path.GetExtension(filename);
-        if (IsExtensionNotAllowed(extension, allowedExtension))
+        if (IsFileExtensionNotAllowed(extension, allowedExtension))
         {
             return Result<Filepath>.Fail(FileExtensionNotAllowedError.Create(extension));
         }

--- a/src/WCNet/CommandResolvers/DefaultCommandResolver.cs
+++ b/src/WCNet/CommandResolvers/DefaultCommandResolver.cs
@@ -9,8 +9,5 @@ internal class DefaultCommandResolver : ICommandResolver
 		_factory = factory;
 	}
 
-    public ICommand ResolveCommand(CommandRequest request)
-    {
-        return _factory.CreateCommand(request);
-    }
+    public ICommand ResolveCommand(CommandRequest request) => _factory.CreateCommand(request);
 }

--- a/src/WCNet/Commands/Concrete/ByteCountCommand.cs
+++ b/src/WCNet/Commands/Concrete/ByteCountCommand.cs
@@ -4,17 +4,16 @@
 internal class ByteCountCommand : ICommand
 {
     private readonly Filepath _filepath;
-    private readonly IOutput _output;
 
-    public ByteCountCommand(Filepath filepath, IOutput output)
+    public ByteCountCommand(Filepath filepath)
     {
         _filepath = filepath;
-        _output = output;
     }
 
-    public void Execute()
+    public Result<Count> Execute()
     {
         var fileInfo = new FileInfo(_filepath);
-        _output.Sink(fileInfo.Length, fileInfo.Name);
+
+        return Result<Count>.Ok(fileInfo.Length);
     }
 }

--- a/src/WCNet/Commands/Concrete/CharacterCountCommand.cs
+++ b/src/WCNet/Commands/Concrete/CharacterCountCommand.cs
@@ -1,29 +1,29 @@
-﻿namespace VP.CodingChallenge.WCNet.Commands.Concrete;
+﻿//namespace VP.CodingChallenge.WCNet.Commands.Concrete;
 
-[CommandKey("m")]
-internal class CharacterCountCommand : ICommand
-{
-    private readonly Filepath _filepath;
-    private readonly IOutput _output;
+//[CommandKey("m")]
+//internal class CharacterCountCommand : ICommand
+//{
+//    private readonly Filepath _filepath;
+//    private readonly IOutput _output;
 
-    public CharacterCountCommand(Filepath filepath, IOutput output)
-    {
-        _filepath = filepath;
-        _output = output;
-    }
+//    public CharacterCountCommand(Filepath filepath, IOutput output)
+//    {
+//        _filepath = filepath;
+//        _output = output;
+//    }
 
-    public void Execute()
-    {
-        var fileInfo = new FileInfo(_filepath);
-        var characterCount = 0L;
-        using var streamReader = new StreamReader(fileInfo.FullName);
-        var line = streamReader.ReadLine();
-        while (line != null)
-        {
-            characterCount += line.Length;
-            line = streamReader.ReadLine();
-        }
+//    public void Execute()
+//    {
+//        var fileInfo = new FileInfo(_filepath);
+//        var characterCount = 0L;
+//        using var streamReader = new StreamReader(fileInfo.FullName);
+//        var line = streamReader.ReadLine();
+//        while (line != null)
+//        {
+//            characterCount += line.Length;
+//            line = streamReader.ReadLine();
+//        }
 
-        _output.Sink(characterCount, fileInfo.Name);
-    }
-}
+//        _output.Sink(characterCount, fileInfo.Name);
+//    }
+//}

--- a/src/WCNet/Commands/Concrete/CommandNotFound.cs
+++ b/src/WCNet/Commands/Concrete/CommandNotFound.cs
@@ -2,13 +2,5 @@
 
 internal class CommandNotFound : ICommand
 {
-    private readonly IOutput _output;
-
-    public CommandNotFound(IOutput output)
-    {
-        _output = output;
-    }
-
-	public void Execute()
-        => _output.Sink(CommandNotFoundError.Create().ToString());
+	public Result<Count> Execute() => Result<Count>.Fail(CommandNotFoundError.Create());
 }

--- a/src/WCNet/Commands/Concrete/CompositeCommand.cs
+++ b/src/WCNet/Commands/Concrete/CompositeCommand.cs
@@ -1,0 +1,24 @@
+﻿//namespace VP.CodingChallenge.WCNet.Commands.Concrete;
+
+//internal class CompositeCommand : ICommand
+//{
+//    private readonly ICollection<ICommand> _commands;
+//    private ICollection<Count> _counts;
+
+//    public CompositeCommand(ICollection<ICommand> commands)
+//    {
+//        _commands = commands;
+//        _counts = new List<Count>(commands.Count);
+//    }
+
+//    public Result<ICollection<Count>> Execute()
+//    {
+//        foreach (var command in _commands)
+//        {
+//            var countResult = command.Execute();
+//            _counts.Add(countResult.Value);
+//        }
+
+//        return Result<ICollection<Count>>.Ok(_counts);
+//    }
+//}

--- a/src/WCNet/Commands/Concrete/LineCountCommand.cs
+++ b/src/WCNet/Commands/Concrete/LineCountCommand.cs
@@ -1,27 +1,27 @@
-﻿namespace VP.CodingChallenge.WCNet.Commands.Concrete;
+﻿//namespace VP.CodingChallenge.WCNet.Commands.Concrete;
 
-[CommandKey("l")]
-internal class LineCountCommand : ICommand
-{
-    private readonly Filepath _filepath;
-    private readonly IOutput _output;
+//[CommandKey("l")]
+//internal class LineCountCommand : ICommand
+//{
+//    private readonly Filepath _filepath;
+//    private readonly IOutput _output;
 
-    public LineCountCommand(Filepath filepath, IOutput output)
-    {
-        _filepath = filepath;
-        _output = output;
-    }
+//    public LineCountCommand(Filepath filepath, IOutput output)
+//    {
+//        _filepath = filepath;
+//        _output = output;
+//    }
 
-    public void Execute()
-	{
-		var fileInfo = new FileInfo(_filepath);
-		var lineCount = 0L;
-		using var streamReader = new StreamReader(fileInfo.FullName);
-		while (streamReader.ReadLine() != null)
-		{
-			lineCount++;
-		}
+//    public void Execute()
+//	{
+//		var fileInfo = new FileInfo(_filepath);
+//		var lineCount = 0L;
+//		using var streamReader = new StreamReader(fileInfo.FullName);
+//		while (streamReader.ReadLine() != null)
+//		{
+//			lineCount++;
+//		}
 
-        _output.Sink(lineCount, fileInfo.Name);
-    }
-}
+//        _output.Sink(lineCount, fileInfo.Name);
+//    }
+//}

--- a/src/WCNet/Commands/Concrete/WordCountCommand.cs
+++ b/src/WCNet/Commands/Concrete/WordCountCommand.cs
@@ -1,22 +1,22 @@
-﻿namespace VP.CodingChallenge.WCNet.Commands.Concrete;
+﻿//namespace VP.CodingChallenge.WCNet.Commands.Concrete;
 
-[CommandKey("w")]
-internal class WordCountCommand : ICommand
-{
-    private readonly Filepath _filepath;
-    private readonly IOutput _output;
+//[CommandKey("w")]
+//internal class WordCountCommand : ICommand
+//{
+//    private readonly Filepath _filepath;
+//    private readonly IOutput _output;
 
-    public WordCountCommand(Filepath filepath, IOutput output)
-    {
-        _filepath = filepath;
-        _output = output;
-    }
+//    public WordCountCommand(Filepath filepath, IOutput output)
+//    {
+//        _filepath = filepath;
+//        _output = output;
+//    }
 
-    public void Execute()
-    {
-        var content = File.ReadAllText(_filepath);
-        var pattern = @"\b\w+\b";
-        var matchCollection = Regex.Matches(content, pattern);
-        _output.Sink(matchCollection.Count, Path.GetFileName(_filepath));
-    }
-}
+//    public void Execute()
+//    {
+//        var content = File.ReadAllText(_filepath);
+//        var pattern = @"\b\w+\b";
+//        var matchCollection = Regex.Matches(content, pattern);
+//        _output.Sink(matchCollection.Count, Path.GetFileName(_filepath));
+//    }
+//}

--- a/src/WCNet/Commands/ICommand.cs
+++ b/src/WCNet/Commands/ICommand.cs
@@ -3,5 +3,5 @@ namespace VP.CodingChallenge.WCNet.Commands;
 
 internal interface ICommand
 {
-	void Execute();
+    Result<Count> Execute();
 }

--- a/src/WCNet/Startup/Program.cs
+++ b/src/WCNet/Startup/Program.cs
@@ -7,7 +7,7 @@ public class Program
 
     static void Main(String[] args)
     {
-        CommandHandlerBase? handler = null;
+        //CommandHandlerBase? handler = null;
         try
         {
             //Build WcNet configuration
@@ -19,17 +19,21 @@ public class Program
                 throw new ParserOptionsLoadFailedException();
             }
 
+            //Get object of TextFileAnalyzer
+
+            //Register the object of TextFileAnalyzer as implementation for all of its interfaces
+
             //Build WcNet service provider
             var serviceProvider = ServiceCollection.BuildWCNetServiceProvider();
 
             //Execute CommandHandlerBase.Main
-            handler = serviceProvider.GetRequiredService<CommandHandlerBase>();
+            var handler = serviceProvider.GetRequiredService<DefaultCommandHandler>();
             handler.Main(commandRequestResult.Value);
         }
         catch (Exception ex)
         {
             Console.WriteLine($"Application terminated. Error: {ex.Message}");
-            handler?.Usage();
+            //handler?.Usage();
         }
     }
 }

--- a/src/WCNet/Startup/WcNetCommandExtension.cs
+++ b/src/WCNet/Startup/WcNetCommandExtension.cs
@@ -1,0 +1,27 @@
+﻿namespace VP.CodingChallenge.WCNet.Startup;
+
+internal static class WcNetCommandExtension
+{
+    //internal static IServiceCollection AddWcNetCommands()
+    //{
+
+    //}
+
+    //private static IServiceCollection AddCountCommands(this IServiceCollection services)
+    //{
+    //    services.AddKeyedSingleton<ICommand>("", (provider, k) =>
+    //    {
+    //        return new ByteCountCommand();
+    //    });
+    //}
+
+    //private static IServiceCollection AddCompositeCommand(this IServiceCollection services)
+    //{
+    //    services.AddSingleton<ICommand>(provider =>
+    //    {
+
+    //    });
+
+    //    return services;
+    //}
+}

--- a/src/WCNet/Startup/WcNetServiceExtension.cs
+++ b/src/WCNet/Startup/WcNetServiceExtension.cs
@@ -20,7 +20,13 @@ internal static class WCNetServiceExtension
             var commandTypes = Assembly
             .GetExecutingAssembly()
             .GetTypes()
-            .Where(type => typeof(ICommand).IsAssignableFrom(type) && !type.IsAbstract && type.IsClass)
+            .Where(type =>
+                //type.GetInterfaces().Any(i =>
+                //    i.IsGenericType &&
+                //    i.GetGenericTypeDefinition() == typeof(ICommand<>)) &&
+                //!type.IsAbstract &&
+                //type.IsClass)
+                typeof(ICommand).IsAssignableFrom(type) && !type.IsAbstract && type.IsClass)
             .ToList();
             var commandTypeMap = new Dictionary<Command, Type>(commandTypes.Count);
             foreach (var type in commandTypes)
@@ -30,8 +36,8 @@ internal static class WCNetServiceExtension
                 commandTypeMap.Add(commandKeyAttribute.Key, type);
             }
 
-            var output = provider.GetRequiredService<IOutput>();
-            return new CountCommandFactory(commandTypeMap, output);
+            //var output = provider.GetRequiredService<IOutput>();
+            return new CountCommandFactory(commandTypeMap);
         });
 
         return services;
@@ -46,6 +52,10 @@ internal static class WCNetServiceExtension
     private static IServiceCollection AddWCNetCommandInvoker(this IServiceCollection services)
         => services.AddSingleton<ICommandInvoker, DefaultCommandInvoker>();
 
+    //private static IServiceCollection AddWCNetCommandHandler(this IServiceCollection services)
+    //    => services.AddSingleton<CommandHandlerBase, DefaultCommandHandler>();
     private static IServiceCollection AddWCNetCommandHandler(this IServiceCollection services)
-        => services.AddSingleton<CommandHandlerBase, DefaultCommandHandler>();
+        => services.AddSingleton<DefaultCommandHandler>();
+
+    //private static IServiceCollection Add
 }

--- a/src/WCNet/Usings.cs
+++ b/src/WCNet/Usings.cs
@@ -4,6 +4,7 @@ global using Microsoft.Extensions.DependencyInjection;
 global using System.Diagnostics.CodeAnalysis;
 global using System.Reflection;
 global using System.Runtime.CompilerServices;
+global using System.Text;
 global using System.Text.Json.Serialization;
 global using System.Text.RegularExpressions;
 global using VP.CodingChallenge.WCNet.Attributes;


### PR DESCRIPTION
# Changes
- Added `CommandNotSetError` class, to return as an error from invoker, when `InvokeCommand` method is called and `command` is `null`.
- Added `Count` struct, mainly to return the count of bytes, lines, words, and characters in a text file.
- Modified `CommandKeyAttribute` to use primary constructor.
- Modified classes by removing `IOutput` injection
- Modified `DefaultCommandHandler` to be used directly by the dependency injection