### PR TITLE
Refactor to async command handling and update .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,3 +10,5 @@
 /test/WCNet/obj
 /test/WCNet/coveragereport
 /test/WCNet/TestResults
+/test/VP.CodingChallenge.WCNet.Benchmark/bin
+/test/VP.CodingChallenge.WCNet.Benchmark/obj

--- a/src/WCNet/CommandFactories/CountCommandFactory.cs
+++ b/src/WCNet/CommandFactories/CountCommandFactory.cs
@@ -3,9 +3,9 @@ namespace VP.CodingChallenge.WCNet.CommandFactories;
 
 internal class CountCommandFactory(IServiceProvider serviceProvider) : ICommandFactory
 {
-    public ICommand CreateCommand(CommandKey commandKey)
+    public IAsyncCommand CreateCommand(CommandKey commandKey)
     {
-        var command = serviceProvider.GetKeyedService<ICommand>(commandKey);
+        var command = serviceProvider.GetKeyedService<IAsyncCommand>(commandKey);
         if (command is null)
         {
             return new CommandNotFound(commandKey);
@@ -14,12 +14,12 @@ internal class CountCommandFactory(IServiceProvider serviceProvider) : ICommandF
         return command;
     }
 
-    public ICollection<ICommand> CreateCommands(IReadOnlyCollection<CommandKey> commandKeys)
+    public ICollection<IAsyncCommand> CreateCommands(IReadOnlyCollection<CommandKey> commandKeys)
     {
-        ICollection<ICommand> commands = commandKeys.Count < 1 ? Array.Empty<ICommand>() : new List<ICommand>(commandKeys.Count);
+        ICollection<IAsyncCommand> commands = commandKeys.Count < 1 ? Array.Empty<IAsyncCommand>() : new List<IAsyncCommand>(commandKeys.Count);
         foreach (var commandKey in commandKeys)
         {
-            var command = serviceProvider.GetKeyedService<ICommand>(commandKey);
+            var command = serviceProvider.GetKeyedService<IAsyncCommand>(commandKey);
             if (command is null)
             {
                 commands.Add(new CommandNotFound(commandKey));

--- a/src/WCNet/CommandFactories/ICommandFactory.cs
+++ b/src/WCNet/CommandFactories/ICommandFactory.cs
@@ -2,6 +2,6 @@
 
 internal interface ICommandFactory
 {
-    ICommand CreateCommand(CommandKey commandKey);
-    ICollection<ICommand> CreateCommands(IReadOnlyCollection<CommandKey> commandKeys);
+    IAsyncCommand CreateCommand(CommandKey commandKey);
+    ICollection<IAsyncCommand> CreateCommands(IReadOnlyCollection<CommandKey> commandKeys);
 }

--- a/src/WCNet/CommandHandlers/AsyncCommandHandlerBase.cs
+++ b/src/WCNet/CommandHandlers/AsyncCommandHandlerBase.cs
@@ -1,0 +1,39 @@
+﻿namespace VP.CodingChallenge.WCNet.CommandHandlers;
+
+public abstract class AsyncCommandHandlerBase(IOutput output)
+{
+    private readonly IOutput _output = output;
+
+    protected abstract Task<Result<Message>> Handle(CommandRequest commandRequest);
+    protected void PostHandle(Message message) => _output.Sink(message);
+
+    public async Task Main(CommandRequest commandRequest)
+    {
+        var messageResult = await Handle(commandRequest);
+        if (messageResult.IsFailed)
+        {
+            Console.WriteLine(messageResult.Error);
+            Usage();
+            return;
+        }
+
+        PostHandle(messageResult.Value);
+    }
+
+    internal static void Usage()
+    {
+        Console.WriteLine("Usage: wc.NET [OPTIONS] [FILE]");
+        Console.WriteLine("Counts lines, characters, words, and bytes in the specified FILE.");
+        Console.WriteLine();
+        Console.WriteLine("Options:");
+        Console.WriteLine("  -c,         Print the byte counts.");
+        Console.WriteLine("  -m,         Print the character counts.");
+        Console.WriteLine("  -l,         Print the line counts.");
+        Console.WriteLine("  -w,         Print the word counts.");
+        Console.WriteLine("              Display this help and exit.");
+        Console.WriteLine();
+        Console.WriteLine("Example:");
+        Console.WriteLine("  wc.NET -lwm filename.txt");
+        Console.WriteLine("  wc.NET --lines --words --chars filename.txt");
+    }
+}

--- a/src/WCNet/CommandHandlers/AsyncDefaultCommandHandler.cs
+++ b/src/WCNet/CommandHandlers/AsyncDefaultCommandHandler.cs
@@ -1,0 +1,35 @@
+﻿namespace VP.CodingChallenge.WCNet.CommandHandlers;
+
+internal class AsyncDefaultCommandHandler(ICommandFactory factory, IAsyncCommandInvoker invoker, IOutput output)
+    : AsyncCommandHandlerBase(output)
+{
+    private readonly ICommandFactory _factory = factory;
+    private readonly IAsyncCommandInvoker _invoker = invoker;
+
+    protected override async Task<Result<Message>> Handle(CommandRequest commandRequest)
+    {
+        var commands = _factory.CreateCommands(commandRequest.CommandKeys);
+        _invoker.SetCommands(commands);
+
+        var countResults = await _invoker.InvokeCommandsAsync();
+        return GetMessage(countResults, commandRequest.Filepath.GetFilename());
+    }
+
+    private static Result<Message> GetMessage(Result<ICollection<Count>> countsResult, String filename)
+    {
+        if (countsResult.IsFailed)
+        {
+            return Result<Message>.Fail(countsResult.Error);
+        }
+
+        var builder = new StringBuilder(countsResult.Value.Count);
+        foreach (var count in countsResult.Value)
+        {
+            builder.Append(count);
+            builder.Append(' ');
+        }
+
+        builder.Append(filename);
+        return Result<Message>.Ok(builder.ToString());
+    }
+}

--- a/src/WCNet/CommandHandlers/AsyncUserCommandHandler.cs
+++ b/src/WCNet/CommandHandlers/AsyncUserCommandHandler.cs
@@ -1,0 +1,28 @@
+﻿namespace VP.CodingChallenge.WCNet.CommandHandlers;
+
+internal class AsyncUserCommandHandler(ICommandFactory factory, IAsyncCommandInvoker invoker, IOutput output)
+    : AsyncCommandHandlerBase(output)
+{
+    private readonly ICommandFactory _factory = factory;
+    private readonly IAsyncCommandInvoker _invoker = invoker;
+
+    protected override async Task<Result<Message>> Handle(CommandRequest commandRequest)
+    {
+        var command = _factory.CreateCommand(commandRequest.CommandKey);
+        _invoker.SetCommand(command);
+
+        var countResult = await _invoker.InvokeCommandAsync();
+        return GetMessage(countResult, commandRequest.Filepath.GetFilename());
+    }
+
+    private static Result<Message> GetMessage(Result<Count> countResult, String filename)
+    {
+        if (countResult.IsFailed)
+        {
+            return Result<Message>.Fail(countResult.Error);
+        }
+
+        var textToDisplay = $"{countResult.Value} {filename}";
+        return Result<Message>.Ok(textToDisplay);
+    }
+}

--- a/src/WCNet/CommandHandlers/DefaultCommandHandler.cs
+++ b/src/WCNet/CommandHandlers/DefaultCommandHandler.cs
@@ -14,7 +14,7 @@ internal class DefaultCommandHandler : CommandHandlerBase
 
     protected override Result<Message> Handle(CommandRequest request)
 	{
-        var commands = _countCommandFactory.CreateCommands(request.DefaultCommandKeys);
+        var commands = _countCommandFactory.CreateCommands(request.CommandKeys);
         _invoker.SetCommands(commands);
         
         var countsResult = _invoker.InvokeCommands();

--- a/src/WCNet/CommandInvokers/AsyncCommandInvoker.cs
+++ b/src/WCNet/CommandInvokers/AsyncCommandInvoker.cs
@@ -1,0 +1,37 @@
+﻿namespace VP.CodingChallenge.WCNet.CommandInvokers;
+
+internal class AsyncCommandInvoker : IAsyncCommandInvoker
+{
+    private IAsyncCommand? _command = null;
+    private ICollection<IAsyncCommand> _commands = Array.Empty<IAsyncCommand>();
+
+    public async Task<Result<Count>> InvokeCommandAsync()
+    {
+        if (_command is null)
+        {
+            return Result<Count>.Fail(CommandNotSetError.Create());
+        }
+
+        return await _command.ExecuteAsync();
+    }
+    public async Task<Result<ICollection<Count>>> InvokeCommandsAsync()
+    {
+        if (_commands.Count == 0)
+        {
+            return Result<ICollection<Count>>.Fail(CommandNotSetError.Create());
+        }
+
+        var commandCounts = new List<Count>(_commands.Count);
+        foreach (var command in _commands)
+        {
+            var countResult = await command.ExecuteAsync();
+            commandCounts.Add(countResult.Value);
+        }
+
+        return Result<ICollection<Count>>.Ok(commandCounts);
+    }
+
+    public void SetCommand(IAsyncCommand command) => _command = command;
+
+    public void SetCommands(ICollection<IAsyncCommand> commands) => _commands = commands;
+}

--- a/src/WCNet/CommandInvokers/CommandInvoker.cs
+++ b/src/WCNet/CommandInvokers/CommandInvoker.cs
@@ -1,39 +1,45 @@
 ﻿[assembly: InternalsVisibleTo("VP.CodingChallenge.WCNet.Tests")]
 namespace VP.CodingChallenge.WCNet.CommandInvokers;
 
-internal class CommandInvoker : ICommandInvoker
+internal class CommandInvoker /*: ICommandInvoker, ICommandsInvoker*/
 {
-    private ICommand? _command = null;
-    private ICollection<ICommand> _commands = Array.Empty<ICommand>();
+    private IAsyncCommand? _command;
+    private ICollection<IAsyncCommand> _commands;
 
-    public Result<Count> InvokeCommand()
+    public CommandInvoker()
     {
-        if (_command == null)
-        {
-            return Result<Count>.Fail(CommandNotSetError.Create());
-        }
-
-        return _command.Execute();
+        _command = null;
+        _commands = Array.Empty<IAsyncCommand>();
     }
 
-    public Result<ICollection<Count>> InvokeCommands()
-    {
-        if (_commands.Count == 0)
-        {
-            return Result<ICollection<Count>>.Fail(CommandNotSetError.Create());
-        }
+    //public Result<Count> InvokeCommand()
+    //{
+    //    if (_command == null)
+    //    {
+    //        return Result<Count>.Fail(CommandNotSetError.Create());
+    //    }
 
-        var counts = new List<Count>(_commands.Count);
-        foreach (var command in _commands)
-        {
-            var countResult = command.Execute();
-            counts.Add(countResult.Value);
-        }
+    //    return _command.ExecuteAsync();
+    //}
 
-        return Result<ICollection<Count>>.Ok(counts);
-    }
+    //public Result<ICollection<Count>> InvokeCommands()
+    //{
+    //    if (_commands.Count == 0)
+    //    {
+    //        return Result<ICollection<Count>>.Fail(CommandNotSetError.Create());
+    //    }
 
-    public void SetCommand(ICommand command) => _command = command;
+    //    var counts = new List<Count>(_commands.Count);
+    //    foreach (var command in _commands)
+    //    {
+    //        var countResult = command.ExecuteAsync();
+    //        counts.Add(countResult.Value);
+    //    }
 
-    public void SetCommands(ICollection<ICommand> commands) => _commands = commands;
+    //    return Result<ICollection<Count>>.Ok(counts);
+    //}
+
+    public void SetCommand(IAsyncCommand command) => _command = command;
+
+    public void SetCommands(ICollection<IAsyncCommand> commands) => _commands = commands;
 }

--- a/src/WCNet/CommandInvokers/IAsyncCommandInvoker.cs
+++ b/src/WCNet/CommandInvokers/IAsyncCommandInvoker.cs
@@ -1,9 +1,9 @@
 ﻿namespace VP.CodingChallenge.WCNet.CommandInvokers;
 
-internal interface ICommandInvoker
+internal interface IAsyncCommandInvoker
 {
     void SetCommand(IAsyncCommand command);
     void SetCommands(ICollection<IAsyncCommand> commands);
-    Result<Count> InvokeCommand();
-    Result<ICollection<Count>> InvokeCommands();
+    Task<Result<Count>> InvokeCommandAsync();
+    Task<Result<ICollection<Count>>> InvokeCommandsAsync();
 }

--- a/src/WCNet/CommandModels/CommandRequest.cs
+++ b/src/WCNet/CommandModels/CommandRequest.cs
@@ -3,7 +3,7 @@
 public class CommandRequest : IEquatable<CommandRequest>
 {
     public CommandKey CommandKey { get; }
-    public IReadOnlyCollection<CommandKey> DefaultCommandKeys { get; }
+    public IReadOnlyCollection<CommandKey> CommandKeys { get; }
     public Boolean IsDefault { get; }
 	public Filepath Filepath { get; }
 
@@ -14,7 +14,7 @@ public class CommandRequest : IEquatable<CommandRequest>
         Boolean isDefault)
     {
         CommandKey = commandKey;
-        DefaultCommandKeys = defaultCommandKeys;
+        CommandKeys = defaultCommandKeys;
         Filepath = filepath;
         IsDefault = isDefault;
     }
@@ -27,7 +27,7 @@ public class CommandRequest : IEquatable<CommandRequest>
 	public override Boolean Equals(Object? obj) => obj is not null && obj is CommandRequest other && Equals(other);
     public override Int32 GetHashCode()
     {
-        var defaultKeysHash = DefaultCommandKeys.Aggregate(0, (hash, key) => HashCode.Combine(hash, key));
+        var defaultKeysHash = CommandKeys.Aggregate(0, (hash, key) => HashCode.Combine(hash, key));
         return HashCode.Combine(CommandKey, Filepath, IsDefault, defaultKeysHash);
     }
 	public override String ToString()
@@ -36,7 +36,7 @@ public class CommandRequest : IEquatable<CommandRequest>
 
         if (IsDefault)
         {
-            return $"Default command keys: {String.Join(", ", DefaultCommandKeys)}, Filename: \"{filename}\"";
+            return $"Default command keys: {String.Join(", ", CommandKeys)}, Filename: \"{filename}\"";
         }
 
         return $"Command key: {CommandKey}, Filename: \"{filename}\"";
@@ -57,7 +57,7 @@ public class CommandRequest : IEquatable<CommandRequest>
             left.CommandKey == right.CommandKey &&
             String.Equals(left.Filepath, right.Filepath, StringComparison.Ordinal) &&
             left.IsDefault == right.IsDefault &&
-            Enumerable.SequenceEqual(left.DefaultCommandKeys, right.DefaultCommandKeys);
+            Enumerable.SequenceEqual(left.CommandKeys, right.CommandKeys);
     }
 	public static Boolean operator !=(CommandRequest? left, CommandRequest? right) => !(left == right);
 }

--- a/src/WCNet/CommandModels/Count.cs
+++ b/src/WCNet/CommandModels/Count.cs
@@ -1,4 +1,5 @@
-﻿namespace VP.CodingChallenge.WCNet.CommandModels;
+﻿[assembly: InternalsVisibleTo("VP.CodingChallenge.WCNet.UnitTests")]
+namespace VP.CodingChallenge.WCNet.CommandModels;
 
 internal readonly struct Count(Int64 value) : IEquatable<Count>
 {

--- a/src/WCNet/CommandReceivers/FileHandlers/Contracts/IAsyncCharacterCountable.cs
+++ b/src/WCNet/CommandReceivers/FileHandlers/Contracts/IAsyncCharacterCountable.cs
@@ -1,6 +1,6 @@
 ﻿namespace VP.CodingChallenge.WCNet.CommandReceivers.FileHandlers.Contracts;
 
-internal interface ILineCountable
+internal interface IAsyncCharacterCountable
 {
-    Int64 GetCount();
+    Task<Int64> GetCountAsync();
 }

--- a/src/WCNet/CommandReceivers/FileHandlers/Contracts/IAsyncLineCountable.cs
+++ b/src/WCNet/CommandReceivers/FileHandlers/Contracts/IAsyncLineCountable.cs
@@ -1,6 +1,6 @@
 ﻿namespace VP.CodingChallenge.WCNet.CommandReceivers.FileHandlers.Contracts;
 
-internal interface ICharacterCountable
+internal interface IAsyncLineCountable
 {
-    Int64 GetCount();
+    Task<Int64> GetCountAsync();
 }

--- a/src/WCNet/CommandReceivers/FileHandlers/Contracts/IAsyncWordCountable.cs
+++ b/src/WCNet/CommandReceivers/FileHandlers/Contracts/IAsyncWordCountable.cs
@@ -1,6 +1,6 @@
 ﻿namespace VP.CodingChallenge.WCNet.CommandReceivers.FileHandlers.Contracts;
 
-internal interface IWordCountable
+internal interface IAsyncWordCountable
 {
-    Int64 GetCount();
+    Task<Int64> GetCountAsync();
 }

--- a/src/WCNet/CommandReceivers/FileHandlers/Document.cs
+++ b/src/WCNet/CommandReceivers/FileHandlers/Document.cs
@@ -1,6 +1,6 @@
 ﻿namespace VP.CodingChallenge.WCNet.CommandReceivers.FileHandlers;
 
-internal class Document(Filepath filepath) : IByteCountable, ICharacterCountable, ILineCountable, IWordCountable
+internal class Document(Filepath filepath) : IByteCountable, IAsyncCharacterCountable, IAsyncLineCountable, IAsyncWordCountable
 {
     private readonly Filepath _filepath = Path.GetFullPath(filepath);
 
@@ -10,38 +10,155 @@ internal class Document(Filepath filepath) : IByteCountable, ICharacterCountable
         return fileInfo.Length;
     }
 
-    Int64 ICharacterCountable.GetCount()
+    async Task<Int64> IAsyncCharacterCountable.GetCountAsync()
     {
         var characterCount = 0L;
-        using var streamReader = new StreamReader(_filepath);
-        var line = streamReader.ReadLine();
-        while (line != null)
+        var bufferSize64KB = 64 * 1024;
+        using var fileStream = new FileStream(filepath, FileMode.Open, FileAccess.Read);
+        var pipeReader = PipeReader.Create(fileStream, new StreamPipeReaderOptions(bufferSize: bufferSize64KB));
+        while (true)
         {
-            characterCount += line.Length;
-            line = streamReader.ReadLine();
+            var readResult = await pipeReader.ReadAsync();
+            var buffer = readResult.Buffer;
+            characterCount += GetCharacterCountInBuffer(buffer);
+            pipeReader.AdvanceTo(buffer.End);
+            if (readResult.IsCompleted)
+            {
+                break;
+            }
         }
+
+        await pipeReader.CompleteAsync();
 
         return characterCount;
     }
 
-    Int64 ILineCountable.GetCount()
+    async Task<Int64> IAsyncLineCountable.GetCountAsync()
     {
         var lineCount = 0L;
-        using var streamReader = new StreamReader(_filepath);
-        while (streamReader.ReadLine() != null)
+        var bufferSize64KB = 64 * 1024;
+        using var fileStream = new FileStream(filepath, FileMode.Open, FileAccess.Read);
+        var pipeReader = PipeReader.Create(fileStream, new StreamPipeReaderOptions(bufferSize: bufferSize64KB));
+        while (true)
         {
-            lineCount++;
+            var readResult = await pipeReader.ReadAsync();
+            var buffer = readResult.Buffer;
+            SequencePosition? endOfLinePosition;
+            do
+            {
+                //Look for EOL in the buffer
+                endOfLinePosition = buffer.PositionOf((Byte)'\n');
+
+                if (endOfLinePosition != null)
+                {
+                    lineCount++;
+                    buffer = buffer.Slice(buffer.GetPosition(1, endOfLinePosition.Value));
+                }
+            }
+            while (endOfLinePosition != null);
+
+            //Tell the PipeReader how much of the buffer has been consumed
+            pipeReader.AdvanceTo(buffer.Start, buffer.End);
+
+            //Stop reading if there is no more data coming
+            if (readResult.IsCompleted)
+            {
+                break;
+            }
         }
+
+        await pipeReader.CompleteAsync();
 
         return lineCount;
     }
 
-    Int64 IWordCountable.GetCount()
+    async Task<Int64> IAsyncWordCountable.GetCountAsync()
     {
-        var content = File.ReadAllText(_filepath);
-        var pattern = @"\b\w+\b";
-        var matchCollection = Regex.Matches(content, pattern);
+        var wordCount = 0L;
+        var bufferSize64KB = 64 * 1024;
+        using var fileStream = new FileStream(filepath, FileMode.Open, FileAccess.Read);
+        var pipeReader = PipeReader.Create(fileStream, new StreamPipeReaderOptions(bufferSize: bufferSize64KB));
+        while (true)
+        {
+            var readResult = await pipeReader.ReadAsync();
+            var buffer = readResult.Buffer;
+            wordCount += GetWordCountInBuffer(buffer);
+            pipeReader.AdvanceTo(buffer.End);
 
-        return matchCollection.Count;
+            if (readResult.IsCompleted)
+            {
+                break;
+            }
+        }
+
+        await pipeReader.CompleteAsync();
+
+        return wordCount;
     }
+
+    #region Private Methods
+    private static Int64 GetCharacterCountInBuffer(ReadOnlySequence<Byte> buffer)
+    {
+        var characterCount = 0L;
+        foreach (var segment in buffer)
+        {
+            characterCount += Encoding.Default.GetCharCount(segment.Span);
+        }
+
+        return characterCount;
+    }
+    private static Int64 GetLineCountInBuffer(ReadOnlySequence<Byte> buffer)
+    {
+        var lineCount = 0L;
+        SequencePosition? endOfLinePosition;
+        do
+        {
+            endOfLinePosition = buffer.PositionOf((Byte)'\n');      //Look for EOL in the buffer
+
+            if (endOfLinePosition != null)
+            {
+                lineCount++;
+                buffer = buffer.Slice(buffer.GetPosition(1, endOfLinePosition.Value));
+            }
+        }
+        while (endOfLinePosition != null);
+
+        return lineCount;
+    }
+    private static Int64 GetWordCountInBuffer(ReadOnlySequence<Byte> buffer)
+    {
+        var wordCount = 0L;
+        var inWord = false;
+        foreach (var segment in buffer)
+        {
+            var span = segment.Span;
+            foreach (var byteValue in span)
+            {
+                if (byteValue is ((Byte)' ') or ((Byte)'\n') or ((Byte)'\r') or ((Byte)'\t'))
+                {
+                    if (inWord)
+                    {
+                        wordCount++;
+                        inWord = false;
+                    }
+                }
+                //else if (Char.IsPunctuation((Char)byteValue) && !inWord)
+                //{
+                //    continue;
+                //}
+                else
+                {
+                    inWord = true;
+                }
+            }
+        }
+
+        if (inWord)
+        {
+            wordCount++;    //Count the last word if it wasn't followed by a whitespace
+        }
+
+        return wordCount;
+    }
+    #endregion Private Methods
 }

--- a/src/WCNet/Commands/Concrete/ByteCountCommand.cs
+++ b/src/WCNet/Commands/Concrete/ByteCountCommand.cs
@@ -1,11 +1,11 @@
 ﻿namespace VP.CodingChallenge.WCNet.Commands.Concrete;
 
 [CommandKey("c")]
-internal class ByteCountCommand(IByteCountable byteCountable) : ICommand
+internal class ByteCountCommand(IByteCountable byteCountable) : IAsyncCommand
 {
-    public Result<Count> Execute()
+    public async Task<Result<Count>> ExecuteAsync()
     {
-        var count = byteCountable.GetCount();
+        var count = await Task.Run(byteCountable.GetCount);
 
         return Result<Count>.Ok(count);
     }

--- a/src/WCNet/Commands/Concrete/CharacterCountCommand.cs
+++ b/src/WCNet/Commands/Concrete/CharacterCountCommand.cs
@@ -1,11 +1,11 @@
 ﻿namespace VP.CodingChallenge.WCNet.Commands.Concrete;
 
 [CommandKey("m")]
-internal class CharacterCountCommand(ICharacterCountable characterCountable) : ICommand
+internal class CharacterCountCommand(IAsyncCharacterCountable characterCountable) : IAsyncCommand
 {
-    public Result<Count> Execute()
+    public async Task<Result<Count>> ExecuteAsync()
     {
-        var characterCount = characterCountable.GetCount();
+        var characterCount = await characterCountable.GetCountAsync();
 
         return Result<Count>.Ok(characterCount);
     }

--- a/src/WCNet/Commands/Concrete/CommandNotFound.cs
+++ b/src/WCNet/Commands/Concrete/CommandNotFound.cs
@@ -1,6 +1,6 @@
 ﻿namespace VP.CodingChallenge.WCNet.Commands.Concrete;
 
-internal class CommandNotFound : ICommand
+internal class CommandNotFound : IAsyncCommand
 {
     private readonly CommandKey _key;
 
@@ -9,5 +9,5 @@ internal class CommandNotFound : ICommand
         _key = key;
     }
 
-	public Result<Count> Execute() => Result<Count>.Fail(CommandNotFoundError.Create(_key));
+	public async Task<Result<Count>> ExecuteAsync() => await Task.Run(() => Result<Count>.Fail(CommandNotFoundError.Create(_key)));
 }

--- a/src/WCNet/Commands/Concrete/LineCountCommand.cs
+++ b/src/WCNet/Commands/Concrete/LineCountCommand.cs
@@ -1,11 +1,11 @@
 ﻿namespace VP.CodingChallenge.WCNet.Commands.Concrete;
 
 [CommandKey("l")]
-internal class LineCountCommand(ILineCountable lineCountable) : ICommand
+internal class LineCountCommand(IAsyncLineCountable lineCountable) : IAsyncCommand
 {
-    public Result<Count> Execute()
+    public async Task<Result<Count>> ExecuteAsync()
     {
-        var lineCount = lineCountable.GetCount();
+        var lineCount = await lineCountable.GetCountAsync();
 
         return Result<Count>.Ok(lineCount);
     }

--- a/src/WCNet/Commands/Concrete/WordCountCommand.cs
+++ b/src/WCNet/Commands/Concrete/WordCountCommand.cs
@@ -1,11 +1,11 @@
 ﻿namespace VP.CodingChallenge.WCNet.Commands.Concrete;
 
 [CommandKey("w")]
-internal class WordCountCommand(IWordCountable wordCountable) : ICommand
+internal class WordCountCommand(IAsyncWordCountable wordCountable) : IAsyncCommand
 {
-    public Result<Count> Execute()
+    public async Task<Result<Count>> ExecuteAsync()
     {
-        var wordCount = wordCountable.GetCount();
+        var wordCount = await wordCountable.GetCountAsync();
 
         return Result<Count>.Ok(wordCount);
     }

--- a/src/WCNet/Commands/IAsyncCommand.cs
+++ b/src/WCNet/Commands/IAsyncCommand.cs
@@ -1,7 +1,7 @@
 ﻿[assembly: InternalsVisibleTo("VP.CodingChallenge.WCNet.Test")]
 namespace VP.CodingChallenge.WCNet.Commands;
 
-internal interface ICommand
+internal interface IAsyncCommand
 {
-    Result<Count> Execute();
+    Task<Result<Count>> ExecuteAsync();
 }

--- a/src/WCNet/Properties/launchSettings.json
+++ b/src/WCNet/Properties/launchSettings.json
@@ -2,7 +2,7 @@
   "profiles": {
     "VP.CodingChallenge.WCNet": {
       "commandName": "Project",
-      "commandLineArgs": "-c test.txt"
+      "commandLineArgs": "-m test.txt"
     }
   }
 }

--- a/src/WCNet/Startup/Program.cs
+++ b/src/WCNet/Startup/Program.cs
@@ -3,7 +3,7 @@
 [ExcludeFromCodeCoverage]
 public class Program
 {
-    static void Main(String[] args)
+    static async Task Main(String[] args)
     {
         try
         {
@@ -20,11 +20,14 @@ public class Program
             var serviceProvider = new ServiceCollection().BuildWCNetServiceProvider(commandRequestResult.Value.Filepath);
 
             //Execute CommandHandlerBase.Main
-            CommandHandlerBase? handler = commandRequestResult.Value.IsDefault
-                ? serviceProvider.GetRequiredService<DefaultCommandHandler>()
-                : serviceProvider.GetRequiredService<UserCommandHandler>();
+            //CommandHandlerBase? handler = commandRequestResult.Value.IsDefault
+            //    ? serviceProvider.GetRequiredService<DefaultCommandHandler>()
+            //    : serviceProvider.GetRequiredService<UserCommandHandler>();
+            AsyncCommandHandlerBase? handler = commandRequestResult.Value.IsDefault
+                ? serviceProvider.GetRequiredService<AsyncDefaultCommandHandler>()
+                : serviceProvider.GetRequiredService<AsyncUserCommandHandler>();
 
-            handler.Main(commandRequestResult.Value);
+            await handler.Main(commandRequestResult.Value);
         }
         catch (Exception ex)
         {

--- a/src/WCNet/Startup/WcNetServiceExtension.cs
+++ b/src/WCNet/Startup/WcNetServiceExtension.cs
@@ -23,7 +23,7 @@ internal static class WCNetServiceExtension
         var commandTypes = Assembly
             .GetExecutingAssembly()
             .GetTypes()
-            .Where(type => typeof(ICommand).IsAssignableFrom(type) && !type.IsAbstract && type.IsClass)
+            .Where(type => typeof(IAsyncCommand).IsAssignableFrom(type) && !type.IsAbstract && type.IsClass)
             .ToList();
 
         foreach (var type in commandTypes)
@@ -31,7 +31,7 @@ internal static class WCNetServiceExtension
             var commandKeyAttribute = type.GetCustomAttribute<CommandKeyAttribute>();
             if (commandKeyAttribute is null) continue;
 
-            services.AddKeyedSingleton(typeof(ICommand), commandKeyAttribute.Key, type);
+            services.AddKeyedSingleton(typeof(IAsyncCommand), commandKeyAttribute.Key, type);
         }
 
         return services;
@@ -41,21 +41,24 @@ internal static class WCNetServiceExtension
         => services.AddSingleton<IOutput, ConsoleOutput>();
 
     private static IServiceCollection AddWCNetCommandInvokers(this IServiceCollection services)
-        => services.AddSingleton<ICommandInvoker, CommandInvoker>();
+        //=> services.AddSingleton<ICommandInvoker, CommandInvoker>();
+        => services.AddSingleton<IAsyncCommandInvoker, AsyncCommandInvoker>();
 
     private static IServiceCollection AddWCNetCommandHandlers(this IServiceCollection services)
         => services
             .AddSingleton<DefaultCommandHandler>()
-            .AddSingleton<UserCommandHandler>();
+            .AddSingleton<UserCommandHandler>()
+            .AddSingleton<AsyncDefaultCommandHandler>()
+            .AddSingleton<AsyncUserCommandHandler>();
 
     private static IServiceCollection AddWCNetFileHandlers(this IServiceCollection services, Filepath filepath)
     {
         var document = new Document(filepath);
         services
             .AddSingleton<IByteCountable>(document)
-            .AddSingleton<ICharacterCountable>(document)
-            .AddSingleton<ILineCountable>(document)
-            .AddSingleton<IWordCountable>(document);
+            .AddSingleton<IAsyncCharacterCountable>(document)
+            .AddSingleton<IAsyncLineCountable>(document)
+            .AddSingleton<IAsyncWordCountable>(document);
 
         return services;
     }

--- a/src/WCNet/Usings.cs
+++ b/src/WCNet/Usings.cs
@@ -1,7 +1,9 @@
 ﻿global using LightResults;
 global using Microsoft.Extensions.Configuration;
 global using Microsoft.Extensions.DependencyInjection;
+global using System.Buffers;
 global using System.Diagnostics.CodeAnalysis;
+global using System.IO.Pipelines;
 global using System.Reflection;
 global using System.Runtime.CompilerServices;
 global using System.Text;

--- a/src/WCNet/VP.CodingChallenge.WCNet.csproj
+++ b/src/WCNet/VP.CodingChallenge.WCNet.csproj
@@ -18,6 +18,7 @@
     <PackageReference Include="Microsoft.Extensions.Configuration.Json" Version="8.0.0" />
     <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="8.0.0" />
     <PackageReference Include="Microsoft.Extensions.Options.ConfigurationExtensions" Version="8.0.0" />
+    <PackageReference Include="System.IO.Pipelines" Version="8.0.0" />
   </ItemGroup>
 
   <ItemGroup>


### PR DESCRIPTION
Updated `.gitignore` to ignore test results and benchmark binaries. Refactored command handling to use asynchronous operations:
- Modified `CountCommandFactory` and `ICommandFactory` for async.
- Introduced `AsyncCommandHandlerBase` and new async handlers.
- Added `AsyncCommandInvoker` and `IAsyncCommandInvoker`.
- Updated `CommandInvoker` and related interfaces for async.
- Updated Document class to use `PipeReader` for file reading.
- Refactored various command classes to implement `IAsyncCommand`.
- Updated `Program` class for `async Main` method.
- Registered async handlers in `WCNetServiceExtension`.
- Updated `Usings.cs` for async namespaces.
- Updated project file to include `System.IO.Pipelines`.