### PR TITLE
Refactored async command handler and invoker

### DIFF
--- a/src/WCNet/CommandHandlers/AsyncCommandsHandler.cs
+++ b/src/WCNet/CommandHandlers/AsyncCommandsHandler.cs
@@ -3,40 +3,50 @@
 internal class AsyncCommandsHandler(ICommandFactory factory, IAsyncCommandInvoker invoker, IOutput output)
     : AsyncCommandHandlerBase(output)
 {
-    protected override async Task<ICollection<Result<Message>>> Handle(CommandRequest commandRequest)
+    protected override async Task<Result<ICollection<Message>>> Handle(CommandRequest commandRequest)
     {
-        var commandKeyCount = commandRequest.CommandKeys.Count;
-        var commands = CreateCommands(commandRequest, commandKeyCount);
-        var messageResults = CreateMessages(commandKeyCount);
-
-        foreach (var command in commands)
-        {
-            var countResult = await InvokeCommandAsync(command);
-            messageResults.Add(GetMessage(countResult, commandRequest.Filepath.GetFilename()));
-        }
+        var keyCount = commandRequest.CommandKeys.Count;
+        var commands = CreateCommands(commandRequest, keyCount);
+        var countResults = await InvokeCommandsAsync(commands);
+        var messageResults = CreateMessages(countResults, commandRequest);
 
         return messageResults;
     }
 
-    private static List<Result<Message>> CreateMessages(Int32 commandKeyCount) => new List<Result<Message>>(commandKeyCount);
+    private static Result<ICollection<Message>> CreateMessages(Result<ICollection<Result<Count>>> countResults, CommandRequest request)
+    {
+        if (countResults.IsFailed)
+        {
+            return Result<ICollection<Message>>.Fail(countResults.Error);
+        }
 
-    private static Result<Message> GetMessage(Result<Count> countResult, String filename)
+        var messages = new List<Message>(countResults.Value.Count);
+        var filename = Path.GetFileName(request.Filepath);
+        foreach (var countResult in countResults.Value)
+        {
+            var message = CreateMessage(countResult, filename);
+            messages.Add(message);
+        }
+
+        return Result<ICollection<Message>>.Ok(messages);
+    }
+
+    private static Message CreateMessage(Result<Count> countResult, String filename)
     {
         if (countResult.IsFailed)
         {
-            return Result<Message>.Fail(countResult.Error);
+            return countResult.Error.Message;
         }
 
-        var textToDisplay = $"{countResult.Value} {filename}";
-        return Result<Message>.Ok(textToDisplay);
+        return $"{countResult.Value} {filename}";
     }
 
-    private async Task<Result<Count>> InvokeCommandAsync(IAsyncCommand command)
+    private async Task<Result<ICollection<Result<Count>>>> InvokeCommandsAsync(List<IAsyncCommand> commands)
     {
-        invoker.SetCommand(command);
-        
-        var countResult = await invoker.InvokeCommandAsync();
-        return countResult;
+        invoker.SetCommands(commands);
+
+        var countResults = await invoker.InvokeCommandsAsync();
+        return countResults;
     }
 
     private List<IAsyncCommand> CreateCommands(CommandRequest request, Int32 commandKeyCount)

--- a/src/WCNet/CommandInvokers/AsyncCommandInvoker.cs
+++ b/src/WCNet/CommandInvokers/AsyncCommandInvoker.cs
@@ -2,36 +2,26 @@
 
 internal class AsyncCommandInvoker : IAsyncCommandInvoker
 {
-    private IAsyncCommand? _command = null;
     private ICollection<IAsyncCommand> _commands = Array.Empty<IAsyncCommand>();
 
-    public async Task<Result<Count>> InvokeCommandAsync()
+    public async Task<Result<ICollection<Result<Count>>>> InvokeCommandsAsync()
     {
-        if (_command is null)
+        if (IsCommandsInvalid())
         {
-            return Result<Count>.Fail(CommandNotSetError.Create());
+            return Result<ICollection<Result<Count>>>.Fail("No command found. Use 'SetCommands' method.");
         }
 
-        return await _command.ExecuteAsync();
-    }
-    public async Task<Result<ICollection<Count>>> InvokeCommandsAsync()
-    {
-        if (_commands.Count == 0)
-        {
-            return Result<ICollection<Count>>.Fail(CommandNotSetError.Create());
-        }
-
-        var commandCounts = new List<Count>(_commands.Count);
+        var commandCounts = new List<Result<Count>>(_commands.Count);
         foreach (var command in _commands)
         {
             var countResult = await command.ExecuteAsync();
-            commandCounts.Add(countResult.Value);
+            commandCounts.Add(countResult);
         }
 
-        return Result<ICollection<Count>>.Ok(commandCounts);
+        return Result<ICollection<Result<Count>>>.Ok(commandCounts);
     }
 
-    public void SetCommand(IAsyncCommand command) => _command = command;
-
     public void SetCommands(ICollection<IAsyncCommand> commands) => _commands = commands;
+
+    private Boolean IsCommandsInvalid() => _commands is null || _commands.Count == 0;
 }

--- a/src/WCNet/CommandInvokers/IAsyncCommandInvoker.cs
+++ b/src/WCNet/CommandInvokers/IAsyncCommandInvoker.cs
@@ -2,8 +2,6 @@
 
 internal interface IAsyncCommandInvoker
 {
-    void SetCommand(IAsyncCommand command);
     void SetCommands(ICollection<IAsyncCommand> commands);
-    Task<Result<Count>> InvokeCommandAsync();
-    Task<Result<ICollection<Count>>> InvokeCommandsAsync();
+    Task<Result<ICollection<Result<Count>>>> InvokeCommandsAsync();
 }


### PR DESCRIPTION
Refactor async command handling and result processing:
- Refactored `AsyncCommandHandlerBase` to change the return type of the `Handle` method from `Task<ICollection<Result<Message>>>` to
`Task<Result<ICollection<Message>>>`, simplifying result and error handling. Updated `PostHandle` and `Main` methods accordingly.
- Updated `AsyncCommandsHandler` to match the new signature in `AsyncCommandHandlerBase`. Added `CreateMessages` method for converting command results to messages. Modified `InvokeCommandsAsync`
to return a collection of results.
- Refactored `AsyncCommandInvoker` by removing `SetCommand` and `InvokeCommandAsync` methods. Added `IsCommandsInvalid` method to validate commands collection. Updated `InvokeCommandsAsync` to return a collection of results.
- Updated `IAsyncCommandInvoker` interface to remove `SetCommand` and `InvokeCommandAsync` methods. Modified `InvokeCommandsAsync` to return a collection of results.