### PR TITLE
Make Count struct public and add comprehensive tests

### DIFF
--- a/src/WCNet/CommandModels/Count.cs
+++ b/src/WCNet/CommandModels/Count.cs
@@ -1,17 +1,17 @@
 ﻿[assembly: InternalsVisibleTo("VP.CodingChallenge.WCNet.UnitTests")]
 namespace VP.CodingChallenge.WCNet.CommandModels;
 
-internal readonly struct Count(Int64 value) : IEquatable<Count>
+public readonly struct Count(Int64 value) : IEquatable<Count>
 {
-    internal Int64 Value { get; } = value;
+    public Int64 Value { get; } = value;
 
     public Boolean Equals(Count other) => Value == other.Value;
 
     public override Boolean Equals(Object? obj) => obj is not null && obj is Count other && Equals(other);
 
-    public override Int32 GetHashCode() => Value.GetHashCode();
+    public override Int32 GetHashCode() => HashCode.Combine(Value);
 
-    public override String ToString() => Value.ToString();
+    public override String ToString() => $"Count=[Value: \"{Value}\"]";
 
     public static implicit operator Int64(Count count) => count.Value;
 
@@ -25,5 +25,5 @@ internal readonly struct Count(Int64 value) : IEquatable<Count>
 
     public static Boolean operator ==(Count left, Count right) => left.Equals(right);
 
-    public static Boolean operator !=(Count left, Count right) => !left.Equals(right);
+    public static Boolean operator !=(Count left, Count right) => !(left == right);
 }

--- a/test/UnitTests/CommandModels/CountTests/CastingOperators.cs
+++ b/test/UnitTests/CommandModels/CountTests/CastingOperators.cs
@@ -1,0 +1,85 @@
+﻿namespace VP.CodingChallenge.WCNet.UnitTest.CommandModels.CountTests;
+
+public class CastingOperators
+{
+	[Theory]
+	[InlineData(0)]
+	[InlineData(Int64.MinValue)]
+	[InlineData(Int64.MaxValue)]
+	public void Successfully_ConvertsInt64ToCount(Int64 expected)
+	{
+		//Arrange
+		Count count = expected;
+
+		//Act
+		var actual = count.Value;
+
+		//Assert
+		actual.Should().Be(expected);
+	}
+
+	[Theory]
+	[InlineData(0)]
+	[InlineData(Int32.MinValue)]
+	[InlineData(Int32.MaxValue)]
+	public void Successfully_ConvertsInt32ToCount(Int32 expected)
+	{
+		//Arrange
+		Count count = expected;
+
+		//Act
+		var actual = count.Value;
+
+		//Assert
+		actual.Should().Be(expected);
+	}
+
+	[Theory]
+	[InlineData(0)]
+	[InlineData(Int16.MinValue)]
+	[InlineData(Int16.MaxValue)]
+	public void Successfully_ConvertsInt16ToCount(Int16 expected)
+	{
+		//Arrange
+		Count count = expected;
+
+		//Act
+		var actual = count.Value;
+
+		//Assert
+		actual.Should().Be(expected);
+	}
+
+	[Theory]
+	[InlineData(0)]
+	[InlineData(Byte.MinValue)]
+	[InlineData(Byte.MaxValue)]
+	public void Successfully_ConvertsByteToCount(Byte expected)
+	{
+		//Arrange
+		Count count = expected;
+
+		//Act
+		var actual = count.Value;
+
+		//Assert
+		actual.Should().Be(expected);
+	}
+
+	[Theory]
+	[InlineData(0)]
+	[InlineData(Int64.MinValue)]
+	[InlineData(Int64.MaxValue)]
+	public void Successfully_ConvertsCountToInt64(Int64 int64)
+	{
+		//Arrange
+		var count = new Count(int64);
+		var expected = count.Value;
+
+		//Act
+		Int64 actual = count;
+
+		//Assert
+		actual.Should().Be(expected);
+	}
+}

--- a/test/UnitTests/CommandModels/CountTests/Equals.cs
+++ b/test/UnitTests/CommandModels/CountTests/Equals.cs
@@ -1,0 +1,253 @@
+﻿namespace VP.CodingChallenge.WCNet.UnitTest.CommandModels.CountTests;
+
+public class Equals
+{
+	#region Equals(Count)
+	[Fact]
+	public void ReturnsFalse_WhenNotEqualAndOtherIsDefaultCount()
+	{
+		//Arrange
+		var current = new Count(Int64.MaxValue);
+		var other = default(Count);
+
+		//Act
+		var actual = current.Equals(other);
+
+		//Assert
+		actual.Should().BeFalse();
+	}
+
+	[Fact]
+	public void ReturnsFalse_WhenNotEqualAndCurrentIsDefaultCount()
+	{
+		//Arrange
+		var current = default(Count);
+		var other = new Count(Int64.MaxValue);
+
+		//Act
+		var actual = current.Equals(other);
+
+		//Assert
+		actual.Should().BeFalse();
+	}
+
+	[Fact]
+	public void ReturnsFalse_WhenNotEqual()
+	{
+		//Arrange
+		var current = new Count(Int64.MaxValue);
+		var other = new Count(Int64.MinValue);
+
+		//Act
+		var actual = current.Equals(other);
+
+		//Assert
+		actual.Should().BeFalse();
+	}
+
+	[Fact]
+	public void ReturnsTrue_WhenEqualAndBothHaveDefaultValue()
+	{
+		//Arrange
+		var current = default(Count);
+		var other = default(Count);
+
+		//Act
+		var actual = current.Equals(other);
+
+		//Assert
+		actual.Should().BeTrue();
+	}
+
+	[Theory]
+	[InlineData(0)]
+	[InlineData(Int64.MinValue)]
+	[InlineData(Int64.MaxValue)]
+	public void ReturnsTrue_WhenEqualAndBothHaveSameValue(Int64 int64)
+	{
+		//Arrange
+		var current = new Count(int64);
+		var other = new Count(int64);
+
+		//Act
+		var actual = current.Equals(other);
+
+		//Assert
+		actual.Should().BeTrue();
+	}
+	#endregion Equals(Count)
+
+	#region Equals(Object)
+	[Fact]
+	public void ReturnsFalse_WhenObjectIsNull()
+	{
+		//Arrange
+		var @this = new Count(Int64.MaxValue);
+		Object? obj = null;
+
+		//Act
+		var actual = @this.Equals(obj);
+
+		//Assert
+		actual.Should().BeFalse();
+	}
+
+	[Fact]
+	public void ReturnsFalse_WhenObjectIsNotOfTypeCount()
+	{
+		//Arrange
+		var @this = new Count(Int64.MaxValue);
+		Object obj = new CommandKey(Int64.MaxValue.ToString());
+
+		//Act
+		var actual = @this.Equals(obj);
+
+		//Assert
+		actual.Should().BeFalse();
+	}
+
+	[Fact]
+	public void ReturnsFalse_WhenObjectIsOfTypeCountButIsNotEqual()
+	{
+		//Arrange
+		var @this = new Count(Int64.MaxValue);
+		Object obj = new Count(Int64.MinValue);
+
+		//Act
+		var actual = @this.Equals(obj);
+
+		//Assert
+		actual.Should().BeFalse();
+	}
+
+	[Fact]
+	public void ReturnsTrue_WhenObjectIsOfTypeCountAndIsEqual()
+	{
+		//Arrange
+		var @this = new Count(Int64.MaxValue);
+		Object obj = new Count(Int64.MaxValue);
+
+		//Act
+		var actual = @this.Equals(obj);
+
+		//Assert
+		actual.Should().BeTrue();
+	}
+	#endregion Equals(Object)
+
+	#region == Operator
+	[Fact]
+	public void ReturnsFalse_WhenLeftIsNull()
+	{
+		//Arrange
+		Count? left = null;
+		var right = new Count(Int64.MaxValue);
+
+		//Act
+		var actual = left == right;
+
+		//Assert
+		actual.Should().BeFalse();
+	}
+
+	[Fact]
+	public void ReturnsFalse_WhenRightIsNull()
+	{
+		//Arrange
+		var left = new Count(Int64.MaxValue);
+		Count? right = null;
+
+		//Act
+		var actual = left == right;
+
+		//Assert
+		actual.Should().BeFalse();
+	}
+
+	[Fact]
+	public void ReturnsFalse_WhenLeftAndRightAreNotEqual()
+	{
+		//Arrange
+		var left = new Count(Int64.MaxValue);
+		var right = new Count(Int64.MinValue);
+
+		//Act
+		var actual = left == right;
+
+		//Assert
+		actual.Should().BeFalse();
+	}
+
+	[Fact]
+	public void ReturnsTrue_WhenLeftAndRightAreNull()
+	{
+		//Arrange
+		Count? left = null;
+		Count? right = null;
+
+		//Act
+		var actual = left == right;
+
+		//Assert
+		actual.Should().BeTrue();
+	}
+
+	[Fact]
+	public void ReturnsTrue_WhenLeftAndRightAreDefault()
+	{
+		//Arrange
+		var left = default(Count);
+		var right = default(Count);
+
+		//Act
+		var actual = left == right;
+
+		//Assert
+		actual.Should().BeTrue();
+	}
+
+	[Fact]
+	public void ReturnsTrue_WhenLeftAndRightAreEqual()
+	{
+		//Arrange
+		var left = new Count(Int64.MaxValue);
+		var right = new Count(Int64.MaxValue);
+
+		//Act
+		var actual = left == right;
+
+		//Assert
+		actual.Should().BeTrue();
+	}
+	#endregion == Operator
+
+	#region != Operator
+	[Fact]
+	public void ReturnsFalse_WhenLeftAndRightAreEqual()
+	{
+		//Arrange
+		var left = new Count(Int64.MaxValue);
+		var right = new Count(Int64.MaxValue);
+
+		//Act
+		var actual = left != right;
+
+		//Assert
+		actual.Should().BeFalse();
+	}
+
+	[Fact]
+	public void ReturnsTrue_WhenLeftAndRightAreNotEqual()
+	{
+		//Arrange
+		var left = new Count(Int64.MaxValue);
+		var right = new Count(Int64.MinValue);
+
+		//Act
+		var actual = left != right;
+
+		//Assert
+		actual.Should().BeTrue();
+	}
+	#endregion != Operator
+}

--- a/test/UnitTests/CommandModels/CountTests/GetHashCode.cs
+++ b/test/UnitTests/CommandModels/CountTests/GetHashCode.cs
@@ -1,0 +1,80 @@
+﻿namespace VP.CodingChallenge.WCNet.UnitTest.CommandModels.CountTests;
+
+public class GetHashCode
+{
+	[Fact]
+	public void ReturnsSameValue_WhenSameInstanceIsCalledMultipleTimes()
+	{
+		//Arrange
+		var count = new Count(Int64.MaxValue);
+		var expected = count.GetHashCode();
+
+		//Act
+		var actual = count.GetHashCode();
+
+		//Assert
+		actual.Should().Be(expected);
+	}
+
+	[Fact]
+	public void ReturnsSameValue_WhenTwoInstancesAreEqual()
+	{
+		//Arrange
+		var count1 = new Count(Int64.MaxValue);
+		var count2 = new Count(Int64.MaxValue);
+		var expected = count1.GetHashCode();
+
+		//Act
+		var actual = count2.GetHashCode();
+
+		//Assert
+		actual.Should().Be(expected);
+		count1.Should().Be(count2);
+	}
+
+	[Fact]
+	public void ReturnsSameValue_WhenTwoInstancesAreDefault()
+	{
+		//Arrange
+		var count1 = default(Count);
+		var count2 = default(Count);
+		var expected = count1.GetHashCode();
+
+		//Act
+		var actual = count2.GetHashCode();
+
+		//Assert
+		actual.Should().Be(expected);
+	}
+
+	[Fact]
+	public void ReturnsDifferentValue_WhenOneOfTheInstancesIsDefault()
+	{
+		//Arrange
+		var count1 = new Count(Int64.MaxValue);
+		var count2 = default(Count);
+		var expected = count1.GetHashCode();
+
+		//Act
+		var actual = count2.GetHashCode();
+
+		//Assert
+		actual.Should().NotBe(expected);
+	}
+
+	[Fact]
+	public void ReturnsDifferentValue_WhenTwoInstancesAreNotEqual()
+	{
+		//Arrange
+		var count1 = new Count(Int64.MaxValue);
+		var count2 = new Count(0L);
+		var expected = count1.GetHashCode();
+
+		//Act
+		var actual = count2.GetHashCode();
+
+		//Assert
+		actual.Should().NotBe(expected);
+		count1.Should().NotBe(count2);
+	}
+}

--- a/test/UnitTests/CommandModels/CountTests/ToString.cs
+++ b/test/UnitTests/CommandModels/CountTests/ToString.cs
@@ -1,0 +1,60 @@
+﻿namespace VP.CodingChallenge.WCNet.UnitTest.CommandModels.CountTests;
+
+public class ToString
+{
+	[Fact]
+	public void ReturnsValueInExpectedFormat_WhenCountIsPositive()
+	{
+		//Arrange
+		var count = new Count(101);
+		var expected = "Count=[Value: \"101\"]";
+
+		//Act
+		var actual = count.ToString();
+
+		//Assert
+		actual.Should().Be(expected);
+	}
+
+	[Fact]
+	public void ReturnsValueInExpectedFormat_WhenCountIsZero()
+	{
+		//Arrange
+		var count = new Count(0);
+		var expected = "Count=[Value: \"0\"]";
+
+		//Act
+		var actual = count.ToString();
+
+		//Assert
+		actual.Should().Be(expected);
+	}
+
+	[Fact]
+	public void ReturnsValueInExpectedFormat_WhenCountIsNegative()
+	{
+		//Arrange
+		var count = new Count(-101);
+		var expected = "Count=[Value: \"-101\"]";
+
+		//Act
+		var actual = count.ToString();
+
+		//Assert
+		actual.Should().Be(expected);
+	}
+
+	[Fact]
+	public void ReturnsValueInExpectedFormat_WhenCountIsDefault()
+	{
+		//Arrange
+		var count = default(Count);
+		var expected = "Count=[Value: \"0\"]";
+
+		//Act
+		var actual = count.ToString();
+
+		//Assert
+		actual.Should().Be(expected);
+	}
+}

--- a/test/UnitTests/VP.CodingChallenge.WCNet.UnitTest.csproj
+++ b/test/UnitTests/VP.CodingChallenge.WCNet.UnitTest.csproj
@@ -25,7 +25,6 @@
   </ItemGroup>
 
   <ItemGroup>
-    <Folder Include="CommandModels\CountTests\" />
     <Folder Include="CommandParsers\" />
     <Folder Include="CommandHandlers\" />
     <Folder Include="CommandInvokers\" />


### PR DESCRIPTION
The `Count` struct in `Count.cs` was modified to change its visibility from `internal` to `public`, allowing access from other assemblies. The `Value` property was also changed from `internal` to `public`.

The `GetHashCode` method in the `Count` struct was updated to use `HashCode.Combine` instead of `Value.GetHashCode`. The `ToString` method was updated to return a formatted string: `Count=[Value: "{Value}"]`. The `!=` operator was modified to use the `==` operator for comparison.

New test classes were added:
- `CastingOperators` in `CastingOperators.cs` to test implicit conversions between `Count` and various integer types.
- `Equals` in `Equals.cs` to test the `Equals` method and equality operators (`==` and `!=`) of the `Count` struct.
- `GetHashCode` in `GetHashCode.cs` to test the `GetHashCode` method of the `Count` struct.
- `ToString` in `ToString.cs` to test the `ToString` method of the `Count` struct.

The `VP.CodingChallenge.WCNet.UnitTest.csproj` file was modified to remove an unnecessary folder inclusion for `CommandModels\CountTests\`.